### PR TITLE
fix: get-app explicitly uses only link

### DIFF
--- a/agent/bench.py
+++ b/agent/bench.py
@@ -209,7 +209,7 @@ class Bench(Base):
             log = data["apps"][name]
             if name not in self.apps:
                 log["get"] = self.execute(
-                    f"bench get-app --branch {branch} {repo} {name}"
+                    f"bench get-app --branch {branch} {repo}"
                 )
 
                 output.append(log["get"]["output"])


### PR DESCRIPTION
> f"bench get-app --branch {branch} {repo} {name}"

The `name` arg is meant to be a placeholder and nothing more in `bench get-app`


![Screenshot 2020-05-26 at 4 35 08 PM](https://user-images.githubusercontent.com/36654812/82893762-276f1900-9f6f-11ea-9dea-a8c8d249b76c.png)




