### PR TITLE
fix(Site): Setup nginx after restore site job

### DIFF
--- a/agent/site.py
+++ b/agent/site.py
@@ -136,6 +136,10 @@ class Site(Base):
         self.set_admin_password(admin_password)
         self.enable_scheduler()
 
+        # only necessary in cases where new site failed before nginx setup
+        self.bench.setup_nginx()
+        self.bench.server.reload_nginx()
+
         return self.bench_execute("list-apps")
 
     @job("Migrate Site")


### PR DESCRIPTION
This is needed in cases where new site (from backup) job fails (usually at migrate), resulting in skipping the Bench setup nginx step. Later attempts to restore site will succeed, but routing will fail.