### PR TITLE
feat: Show different suspension page for SaaS sites

### DIFF
--- a/agent/pages/suspended_saas.html
+++ b/agent/pages/suspended_saas.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>This Site is Suspended</title>
+        <style>
+            html {
+                -webkit-font-smoothing: antialiased;
+                -moz-osx-font-smoothing: grayscale;
+            }
+            body {
+                font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+                color: #1A4469;
+                background-color: #F9FAFA;
+            }
+
+            .container {
+                padding-top: 4rem;
+                max-width: 768px;
+                margin: 0 auto;
+            }
+
+            .logo {
+                text-align: center;
+            }
+
+            .logo svg {
+                height: 1rem;
+            }
+
+            .message-container {
+                width: 24rem;
+                margin: 0 auto;
+                background-color: white;
+                padding: 2.5rem;
+                margin-top: 1.5rem;
+                -webkit-box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+                box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+                font-size: 13px;
+                text-align: center;
+                border-radius: 0.375rem;
+            }
+
+            .alert-icon svg {
+                height: 2rem;
+                width: 2rem;
+            }
+
+            h1 {
+                font-size: 16px;
+                font-weight: 500;
+            }
+
+            p {
+                color: #4C5A67;
+                line-height: 1.5;
+            }
+
+            a {
+                color: #1579D0;
+                text-decoration: none;
+                border-bottom: 1px solid #1579D0;
+            }
+        </style>
+    </head>
+
+    <body>
+        <div class="container">
+            <div class="message-container">
+                <div class="alert-icon">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <path fill-rule="evenodd" clip-rule="evenodd"
+                            d="M4.00288 21.3966C2.47791 21.3966 1.51397 19.7584 2.25456 18.4253L10.2527 4.02871C11.0147 2.65709 12.9873 2.6571 13.7493 4.02872L21.7474 18.4253C22.488 19.7584 21.524 21.3966 19.9991 21.3966H4.00288ZM11.9991 18.4126C12.5688 18.4126 13.0307 17.9507 13.0307 17.381C13.0307 16.8113 12.5688 16.3495 11.9991 16.3495C11.4294 16.3495 10.9675 16.8113 10.9675 17.381C10.9675 17.9507 11.4294 18.4126 11.9991 18.4126ZM13 8.8601C13 8.30782 12.5523 7.8601 12 7.8601C11.4477 7.8601 11 8.30782 11 8.8601V13.9074C11 14.4597 11.4477 14.9074 12 14.9074C12.5523 14.9074 13 14.4597 13 13.9074V8.8601Z"
+                            fill="#D6932E" />
+                    </svg>
+                </div>
+                <h1>
+                    This Site is Suspended.
+                </h1>
+                <p class="message">
+                    This site has been suspended due to exceeding site limits or a payment failure. If you are the owner
+                    of this site, resolve issues related to your site's plan from the <a href="https://frappecloud.com/dashboard/saas/login">Dashboard</a>.
+                </p>
+            </div>
+        </div>
+    </body>
+</html>
+

--- a/agent/proxy.py
+++ b/agent/proxy.py
@@ -287,7 +287,11 @@ class Proxy(Server):
                 for site in os.listdir(upstream_directory):
                     with open(os.path.join(upstream_directory, site)) as f:
                         status = f.read().strip()
-                    if status in ("deactivated", "suspended", "suspended_saas"):
+                    if status in (
+                        "deactivated",
+                        "suspended",
+                        "suspended_saas",
+                    ):
                         actual_upstream = status
                     else:
                         actual_upstream = hashed_upstream

--- a/agent/proxy.py
+++ b/agent/proxy.py
@@ -287,7 +287,7 @@ class Proxy(Server):
                 for site in os.listdir(upstream_directory):
                     with open(os.path.join(upstream_directory, site)) as f:
                         status = f.read().strip()
-                    if status in ("deactivated", "suspended"):
+                    if status in ("deactivated", "suspended", "suspended_saas"):
                         actual_upstream = status
                     else:
                         actual_upstream = hashed_upstream

--- a/agent/templates/proxy/nginx.conf.jinja2
+++ b/agent/templates/proxy/nginx.conf.jinja2
@@ -20,6 +20,11 @@ upstream suspended {
 	keepalive 100;
 }
 
+upstream suspended_saas {
+	server 127.0.0.1:10093;
+	keepalive 100;
+}
+
 map $actual_host $upstream_server_hash {
 {% for upstream in upstreams.values() -%}
 	{% for site in upstream["sites"] %}
@@ -227,6 +232,22 @@ server {
 	}
 
 	location = /suspended.html {
+		internal;
+	}
+}
+
+
+server {
+	listen 127.0.0.1:10093;
+
+	root {{ error_pages_directory }};
+	error_page 402 /suspended_saas.html;
+
+	location / {
+		return 402;
+	}
+
+	location = /suspended_saas.html {
 		internal;
 	}
 


### PR DESCRIPTION
Shows a different suspension via proxy for SaaS sites to redirect users to SaaS dashboard instead of Frappecloud dashboard