### PR TITLE
fix: Cluster backups for unsupported regions

### DIFF
--- a/agent/server.py
+++ b/agent/server.py
@@ -278,7 +278,8 @@ class Server(Base):
     def move_site_to_bench(
         self, name, source, target, deactivate, activate, skip_failing_patches
     ):
-        # Dangerous method (no backup), use update_site_migrate if you don't know what you're doing
+        # Dangerous method (no backup),
+        # use update_site_migrate if you don't know what you're doing
         source = Bench(source, self)
         target = Bench(target, self)
         site = Site(name, source)

--- a/agent/site.py
+++ b/agent/site.py
@@ -326,11 +326,21 @@ class Site(Base):
             offsite["auth"],
             offsite["path"],
         )
-        s3 = boto3.client(
-            "s3",
-            aws_access_key_id=auth["ACCESS_KEY"],
-            aws_secret_access_key=auth["SECRET_KEY"],
-        )
+        region = auth.get("REGION")
+
+        if region:
+            s3 = boto3.client(
+                "s3",
+                aws_access_key_id=auth["ACCESS_KEY"],
+                aws_secret_access_key=auth["SECRET_KEY"],
+                region=region,
+            )
+        else:
+            s3 = boto3.client(
+                "s3",
+                aws_access_key_id=auth["ACCESS_KEY"],
+                aws_secret_access_key=auth["SECRET_KEY"],
+            )
 
         for backup_file in backup_files.values():
             file_name = backup_file["file"].split(os.sep)[-1]

--- a/agent/site.py
+++ b/agent/site.py
@@ -333,7 +333,7 @@ class Site(Base):
                 "s3",
                 aws_access_key_id=auth["ACCESS_KEY"],
                 aws_secret_access_key=auth["SECRET_KEY"],
-                region=region,
+                region_name=region,
             )
         else:
             s3 = boto3.client(


### PR DESCRIPTION
* Some regions need the region_name to be explicitly while uploading an object