### PR TITLE
fix(Site): Move build search index to separate step

### DIFF
--- a/agent/server.py
+++ b/agent/server.py
@@ -259,7 +259,6 @@ class Server(Base):
         site.migrate(
             skip_search_index=True, skip_failing_patches=skip_failing_patches
         )
-        site.build_search_index()
 
         try:
             site.bench_execute(
@@ -272,6 +271,7 @@ class Server(Base):
 
         if activate:
             site.disable_maintenance_mode()
+        site.build_search_index()
 
     @job("Recover Failed Site Migrate", priority="high")
     def update_site_recover_migrate_job(self, name, source, target, activate):

--- a/agent/server.py
+++ b/agent/server.py
@@ -256,7 +256,10 @@ class Server(Base):
         if before_migrate_scripts:
             site.run_before_migrate_scripts(before_migrate_scripts)
 
-        site.migrate(skip_failing_patches=skip_failing_patches)
+        site.migrate(
+            skip_search_index=True, skip_failing_patches=skip_failing_patches
+        )
+        site.build_search_index()
 
         try:
             site.bench_execute(

--- a/agent/site.py
+++ b/agent/site.py
@@ -466,11 +466,17 @@ class Site(Base):
             self.bench_execute("console", input=script)
 
     @step("Migrate Site")
-    def migrate(self, skip_failing_patches=False):
+    def migrate(self, skip_search_index=False, skip_failing_patches=False):
+        cmd = "migrate"
+        if skip_search_index:
+            cmd += " --skip-search-index"
         if skip_failing_patches:
-            return self.bench_execute("migrate --skip-failing")
-        else:
-            return self.bench_execute("migrate")
+            cmd += " --skip-failing"
+        return self.bench_execute(cmd)
+
+    @step("Build Search Index")
+    def build_search_index(self):
+        return self.bench_execute("build-search-index")
 
     @job("Clear Cache")
     def clear_cache_job(self):


### PR DESCRIPTION
Rebuild search index happens in background which may not end before recover site migrate job. This ends up leaving residue in site directory preventing further updates. 

![image](https://user-images.githubusercontent.com/25403045/234070174-418902c7-db97-4e60-b416-99ca2d9a0325.png)

Moving it to foreground as separate step after migrate should fix this.

