### PR TITLE
perf: Make long worker consume short and default queue too

### DIFF
--- a/agent/templates/bench/supervisor.conf
+++ b/agent/templates/bench/supervisor.conf
@@ -58,7 +58,7 @@ numprocs={{ background_workers }}
 process_name=%(program_name)s-%(process_num)d
 
 [program:frappe-bench-frappe-long-worker]
-command=bench worker --queue long
+command=bench worker --queue long,default,short
 priority=4
 autostart=true
 autorestart=true


### PR DESCRIPTION
Refer https://github.com/frappe/press/pull/893
