### PR TITLE
fix: Don't over-reload nginx for suspends and archives

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+exclude: "node_modules|.git"
+default_stages: [commit]
+fail_fast: false
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: debug-statements
+      - id: trailing-whitespace
+        files: "agent.*"
+        exclude: ".*json$|.*txt$|.*csv|.*md|.*svg"
+      - id: check-merge-conflict
+      - id: check-ast
+      - id: check-json
+      - id: check-toml
+      - id: check-yaml
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v1.2.3
+    hooks:
+      - id: flake8
+
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black
+        args: ["-l", "79"]

--- a/agent/proxy.py
+++ b/agent/proxy.py
@@ -241,7 +241,6 @@ class Proxy(Server):
 
     def is_nginx_reloading(self) -> bool:
         global ttl_cache
-        ttl_cache.expire()
         if ttl_cache.get("reloading") is None:
             shutting_down_processes = int(
                 self.execute(
@@ -250,7 +249,9 @@ class Proxy(Server):
             )
             if shutting_down_processes > 0:
                 ttl_cache["reloading"] = True
-        return ttl_cache["reloading"]
+            else:
+                return False  # Only True result needs to stay for TTL seconds
+        return ttl_cache.get("reloading", True)
 
     @step("Reload NGINX")
     def reload_nginx(self, skip_if_reloading=False):

--- a/agent/proxy.py
+++ b/agent/proxy.py
@@ -253,10 +253,10 @@ class Proxy(Server):
         return self.execute("sudo systemctl reload nginx")
 
     @step("Generate NGINX Configuration")
-    @cached(cache=TTLCache(maxsize=128, ttl=10))
     def generate_proxy_config(self):
         return self._generate_proxy_config()
 
+    @cached(cache=TTLCache(maxsize=128, ttl=10))
     def _generate_proxy_config(self):
         proxy_config_file = os.path.join(self.nginx_directory, "proxy.conf")
         self._render_template(

--- a/agent/proxy.py
+++ b/agent/proxy.py
@@ -240,7 +240,7 @@ class Proxy(Server):
         shutting_down_processes = int(
             self.execute(
                 "ps ef | grep 'nginx: worker process is shutting down' | grep -v grep | wc -l"
-            )
+            )["output"]
         )
         if shutting_down_processes > 0:
             return True

--- a/agent/proxy.py
+++ b/agent/proxy.py
@@ -255,7 +255,7 @@ class Proxy(Server):
 
     @step("Reload NGINX")
     def reload_nginx(self, skip_if_reloading=False):
-        if skip_if_reloading and self.is_nginx_reloading:
+        if skip_if_reloading and self.is_nginx_reloading():
             return
         return self.execute("sudo systemctl reload nginx")
 

--- a/agent/proxy.py
+++ b/agent/proxy.py
@@ -242,7 +242,7 @@ class Proxy(Server):
     def is_nginx_reloading(self) -> bool:
         global ttl_cache
         ttl_cache.expire()
-        if ttl_cache["reloading"] is None:
+        if ttl_cache.get("reloading") is None:
             shutting_down_processes = int(
                 self.execute(
                     "ps ax | grep 'nginx: worker process is shutting down' | grep -v grep | wc -l"

--- a/agent/proxy.py
+++ b/agent/proxy.py
@@ -118,15 +118,15 @@ class Proxy(Server):
         shutil.rmtree(host_directory)
 
     @job("Remove Site from Upstream")
-    def remove_site_from_upstream_job(
-        self, upstream, site, skip_if_reloading=True
-    ):
+    def remove_site_from_upstream_job(self, upstream, site, skip_reload=False):
         upstream_directory = os.path.join(self.upstreams_directory, upstream)
         site_file = os.path.join(upstream_directory, site)
         if os.path.exists(site_file):
             self.remove_site_from_upstream(site_file)
+        if skip_reload:
+            return
         self.generate_proxy_config()
-        self.reload_nginx(skip_if_reloading)
+        self.reload_nginx()
 
     @step("Remove Site File from Upstream Directory")
     def remove_site_from_upstream(self, site_file):
@@ -187,9 +187,9 @@ class Proxy(Server):
         self, upstream, site, status, skip_reload=False
     ):
         self.update_site_status(upstream, site, status)
-        self.generate_proxy_config()
         if skip_reload:
             return
+        self.generate_proxy_config()
         self.reload_nginx()
 
     @step("Update Site File")
@@ -246,6 +246,7 @@ class Proxy(Server):
 
     @job("Reload NGINX Job")
     def reload_nginx_job(self):
+        self.generate_proxy_config()
         self.reload_nginx()
 
     @step("Generate NGINX Configuration")

--- a/agent/proxy.py
+++ b/agent/proxy.py
@@ -244,6 +244,10 @@ class Proxy(Server):
     def reload_nginx(self):
         return self.execute("sudo systemctl reload nginx")
 
+    @job("Reload NGINX Job")
+    def reload_nginx_job(self):
+        self.reload_nginx()
+
     @step("Generate NGINX Configuration")
     def generate_proxy_config(self):
         return self._generate_proxy_config()

--- a/agent/proxy.py
+++ b/agent/proxy.py
@@ -237,7 +237,6 @@ class Proxy(Server):
             # default domain
             os.rmdir(host_directory)
 
-    @cached(cache=TTLCache(maxsize=128, ttl=10))
     def is_nginx_reloading(self) -> bool:
         state = self.execute("systemctl show nginx --property=ActiveState")
         return state == "ActiveState=reloading"

--- a/agent/proxy.py
+++ b/agent/proxy.py
@@ -239,7 +239,7 @@ class Proxy(Server):
     def is_nginx_reloading(self) -> bool:
         shutting_down_processes = int(
             self.execute(
-                "ps ef | grep 'nginx: worker process is shutting down' | grep -v grep | wc -l"
+                "ps ax | grep 'nginx: worker process is shutting down' | grep -v grep | wc -l"
             )["output"]
         )
         if shutting_down_processes > 0:

--- a/agent/proxy.py
+++ b/agent/proxy.py
@@ -241,6 +241,7 @@ class Proxy(Server):
 
     def is_nginx_reloading(self) -> bool:
         global ttl_cache
+        ttl_cache.expire()
         if ttl_cache["reloading"] is None:
             shutting_down_processes = int(
                 self.execute(

--- a/agent/proxy.py
+++ b/agent/proxy.py
@@ -1,7 +1,6 @@
 import json
 import os
 import shutil
-from cachetools import cached, TTLCache
 from hashlib import sha512 as sha
 from pathlib import Path
 from typing import Dict, List
@@ -256,7 +255,6 @@ class Proxy(Server):
     def generate_proxy_config(self):
         return self._generate_proxy_config()
 
-    @cached(cache=TTLCache(maxsize=128, ttl=10))
     def _generate_proxy_config(self):
         proxy_config_file = os.path.join(self.nginx_directory, "proxy.conf")
         self._render_template(

--- a/agent/proxy.py
+++ b/agent/proxy.py
@@ -187,7 +187,7 @@ class Proxy(Server):
     def update_site_status_job(self, upstream, site, status):
         self.update_site_status(upstream, site, status)
         self.generate_proxy_config()
-        self.reload_nginx(status == "suspended")
+        self.reload_nginx(status in ["suspended", "suspended_saas"])
 
     @step("Update Site File")
     def update_site_status(self, upstream, site, status):
@@ -249,6 +249,7 @@ class Proxy(Server):
         return self.execute("sudo systemctl reload nginx")
 
     @step("Generate NGINX Configuration")
+    @cached(cache=TTLCache(maxsize=128, ttl=10))
     def generate_proxy_config(self):
         return self._generate_proxy_config()
 

--- a/agent/proxy.py
+++ b/agent/proxy.py
@@ -238,8 +238,13 @@ class Proxy(Server):
             os.rmdir(host_directory)
 
     def is_nginx_reloading(self) -> bool:
-        state = self.execute("systemctl show nginx --property=ActiveState")
-        return state == "ActiveState=reloading"
+        shutting_down_processes = int(
+            self.execute(
+                "ps ef | grep 'nginx: worker process is shutting down' | grep -v grep | wc -l"
+            )
+        )
+        if shutting_down_processes > 0:
+            return True
 
     @step("Reload NGINX")
     def reload_nginx(self, skip_if_reloading=False):

--- a/agent/tests/test_proxy.py
+++ b/agent/tests/test_proxy.py
@@ -302,23 +302,3 @@ class TestProxy(unittest.TestCase):
             self.assertDictEqual(
                 json.load(m), {self.domain_1: "yyy.frappe.cloud"}
             )
-
-    @patch("agent.proxy.Proxy.execute", wraps=lambda x: {"output": "1"})
-    def test_is_nginx_reloading_true_result_is_cached_for_10s(self, mock_execute):
-        proxy = self._get_fake_proxy()
-        self.assertTrue(proxy.is_nginx_reloading())
-        mock_execute.assert_called_once()
-        self.assertTrue(proxy.is_nginx_reloading())
-        mock_execute.assert_called_once()
-        import time
-        time.sleep(10)
-        self.assertTrue(proxy.is_nginx_reloading())
-        self.assertEqual(mock_execute.call_count, 2)
-
-    @patch("agent.proxy.Proxy.execute", wraps=lambda x: {"output": "0"})
-    def test_is_nginx_reloading_false_result_is_not_cached(self, mock_execute):
-        proxy = self._get_fake_proxy()
-        self.assertFalse(proxy.is_nginx_reloading())
-        mock_execute.assert_called_once()
-        self.assertFalse(proxy.is_nginx_reloading())
-        self.assertEqual(mock_execute.call_count, 2)

--- a/agent/tests/test_proxy.py
+++ b/agent/tests/test_proxy.py
@@ -311,5 +311,3 @@ class TestProxy(unittest.TestCase):
         self.assertEqual(mock_execute.call_count, 1)
         proxy.is_nginx_reloading()
         self.assertEqual(mock_execute.call_count, 1)
-
-

--- a/agent/tests/test_proxy.py
+++ b/agent/tests/test_proxy.py
@@ -302,3 +302,23 @@ class TestProxy(unittest.TestCase):
             self.assertDictEqual(
                 json.load(m), {self.domain_1: "yyy.frappe.cloud"}
             )
+
+    @patch("agent.proxy.Proxy.execute", wraps=lambda x: {"output": "1"})
+    def test_is_nginx_reloading_true_result_is_cached_for_10s(self, mock_execute):
+        proxy = self._get_fake_proxy()
+        self.assertTrue(proxy.is_nginx_reloading())
+        mock_execute.assert_called_once()
+        self.assertTrue(proxy.is_nginx_reloading())
+        mock_execute.assert_called_once()
+        import time
+        time.sleep(10)
+        self.assertTrue(proxy.is_nginx_reloading())
+        self.assertEqual(mock_execute.call_count, 2)
+
+    @patch("agent.proxy.Proxy.execute", wraps=lambda x: {"output": "0"})
+    def test_is_nginx_reloading_false_result_is_not_cached(self, mock_execute):
+        proxy = self._get_fake_proxy()
+        self.assertFalse(proxy.is_nginx_reloading())
+        mock_execute.assert_called_once()
+        self.assertFalse(proxy.is_nginx_reloading())
+        self.assertEqual(mock_execute.call_count, 2)

--- a/agent/tests/test_proxy.py
+++ b/agent/tests/test_proxy.py
@@ -302,3 +302,14 @@ class TestProxy(unittest.TestCase):
             self.assertDictEqual(
                 json.load(m), {self.domain_1: "yyy.frappe.cloud"}
             )
+
+    @patch("agent.proxy.Proxy.execute", wraps=lambda x: "ActiveState=reloading")
+    def test_is_nginx_reloading_returns_cached_value_in_timeframe(self, mock_execute):
+        """Test is_nginx_reloading returns cached value."""
+        proxy = self._get_fake_proxy()
+        proxy.is_nginx_reloading()
+        self.assertEqual(mock_execute.call_count, 1)
+        proxy.is_nginx_reloading()
+        self.assertEqual(mock_execute.call_count, 1)
+
+

--- a/agent/tests/test_proxy.py
+++ b/agent/tests/test_proxy.py
@@ -302,12 +302,3 @@ class TestProxy(unittest.TestCase):
             self.assertDictEqual(
                 json.load(m), {self.domain_1: "yyy.frappe.cloud"}
             )
-
-    @patch("agent.proxy.Proxy.execute", wraps=lambda x: "ActiveState=reloading")
-    def test_is_nginx_reloading_returns_cached_value_in_timeframe(self, mock_execute):
-        """Test is_nginx_reloading returns cached value."""
-        proxy = self._get_fake_proxy()
-        proxy.is_nginx_reloading()
-        self.assertEqual(mock_execute.call_count, 1)
-        proxy.is_nginx_reloading()
-        self.assertEqual(mock_execute.call_count, 1)

--- a/agent/web.py
+++ b/agent/web.py
@@ -688,7 +688,9 @@ def proxy_rename_upstream_site(upstream, site):
 )
 def update_site_status(upstream, site):
     data = request.json
-    job = Proxy().update_site_status_job(upstream, site, data["status"])
+    job = Proxy().update_site_status_job(
+        upstream, site, data["status"], data.get("skip_reload", False)
+    )
     return {"job": job}
 
 

--- a/agent/web.py
+++ b/agent/web.py
@@ -669,7 +669,8 @@ def proxy_add_upstream_site(upstream):
     methods=["DELETE"],
 )
 def proxy_remove_upstream_site(upstream, site):
-    job = Proxy().remove_site_from_upstream_job(upstream, site)
+    data = request.json
+    job = Proxy().remove_site_from_upstream_job(upstream, site, data.get("skip_reload", False)))
     return {"job": job}
 
 

--- a/agent/web.py
+++ b/agent/web.py
@@ -670,7 +670,7 @@ def proxy_add_upstream_site(upstream):
 )
 def proxy_remove_upstream_site(upstream, site):
     data = request.json
-    job = Proxy().remove_site_from_upstream_job(upstream, site, data.get("skip_reload", False)))
+    job = Proxy().remove_site_from_upstream_job(upstream, site, data.get("skip_reload", False))
     return {"job": job}
 
 

--- a/agent/web.py
+++ b/agent/web.py
@@ -112,6 +112,12 @@ def restart_nginx():
     return {"job": job}
 
 
+@application.route("/proxy/reload", methods=["POST"])
+def reload_nginx():
+    job = Proxy().reload_nginx_job()
+    return {"job": job}
+
+
 @application.route("/server/status", methods=["POST"])
 def get_server_status():
     data = request.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ rq==1.13.0
 urllib3==1.25.7
 Werkzeug==0.16.0
 wrapt==1.11.2
+cachetools==5.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,3 @@ rq==1.13.0
 urllib3==1.25.7
 Werkzeug==0.16.0
 wrapt==1.11.2
-cachetools==5.3.1


### PR DESCRIPTION
![image](https://github.com/frappe/agent/assets/25403045/69756dd6-9e72-48ab-80a7-84b503280895)

As tested on 4 core (for more nginx processes) machine and running 1000+ jobs