### PR TITLE
feat: Show invalid site config when present

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,8 @@ repos:
     rev: v1.2.3
     hooks:
       - id: flake8
+        args: [--ignore, 'E501,W503']
+
 
   - repo: https://github.com/psf/black
     rev: 23.7.0

--- a/agent/bench.py
+++ b/agent/bench.py
@@ -684,10 +684,14 @@ class Bench(Base):
             try:
                 sites[directory] = Site(directory, self)
             except json.decoder.JSONDecodeError as jde:
-                print("Error decoding JSON in", directory)
-                print(jde.doc)
-                print(jde)
-                raise
+                output = (
+                    f"Error parsing JSON in {directory}:\n"
+                    f"{jde.doc}\n"
+                    f"{jde}\n"
+                )
+                self.execute(
+                    f"echo '{output}';exit 1"
+                )  # exit 1 to make sure the job fails and shows output
             except Exception:
                 pass
         return sites

--- a/agent/bench.py
+++ b/agent/bench.py
@@ -683,6 +683,11 @@ class Bench(Base):
         for directory in os.listdir(self.sites_directory):
             try:
                 sites[directory] = Site(directory, self)
+            except json.decoder.JSONDecodeError as jde:
+                print("Error decoding JSON in", directory)
+                print(jde.doc)
+                print(jde)
+                raise
             except Exception:
                 pass
         return sites

--- a/agent/bench.py
+++ b/agent/bench.py
@@ -677,6 +677,16 @@ class Bench(Base):
     def job_record(self):
         return self.server.job_record
 
+    def readable_jde_err(self, jde: json.decoder.JSONDecodeError) -> str:
+        output = f"Error parsing JSON:\n" f"{jde.doc}\n" f"{jde}\n"
+        import re
+
+        output = re.sub(r'("db_name":.* ")(\w*)(")', r"\1********\3", output)
+        output = re.sub(
+            r'("db_password":.* ")(\w*)(")', r"\1********\3", output
+        )
+        return output
+
     @property
     def sites(self) -> Dict[str, Site]:
         sites = {}
@@ -684,13 +694,8 @@ class Bench(Base):
             try:
                 sites[directory] = Site(directory, self)
             except json.decoder.JSONDecodeError as jde:
-                output = (
-                    f"Error parsing JSON in {directory}:\n"
-                    f"{jde.doc}\n"
-                    f"{jde}\n"
-                )
                 self.execute(
-                    f"echo '{output}';exit 1"
+                    f"echo '{self.readable_jde_err(jde)}';exit 1"
                 )  # exit 1 to make sure the job fails and shows output
             except Exception:
                 pass

--- a/agent/bench.py
+++ b/agent/bench.py
@@ -677,8 +677,10 @@ class Bench(Base):
     def job_record(self):
         return self.server.job_record
 
-    def readable_jde_err(self, jde: json.decoder.JSONDecodeError) -> str:
-        output = f"Error parsing JSON:\n" f"{jde.doc}\n" f"{jde}\n"
+    def readable_jde_err(
+        self, title: str, jde: json.decoder.JSONDecodeError
+    ) -> str:
+        output = f"{title}:\n" f"{jde.doc}\n" f"{jde}\n"
         import re
 
         output = re.sub(r'("db_name":.* ")(\w*)(")', r"\1********\3", output)
@@ -694,8 +696,11 @@ class Bench(Base):
             try:
                 sites[directory] = Site(directory, self)
             except json.decoder.JSONDecodeError as jde:
+                output = self.readable_jde_err(
+                    f"Error parsing JSON in {directory}", jde
+                )
                 self.execute(
-                    f"echo '{self.readable_jde_err(jde)}';exit 1"
+                    f"echo '{output}';exit 1"
                 )  # exit 1 to make sure the job fails and shows output
             except Exception:
                 pass

--- a/agent/tests/test_site.py
+++ b/agent/tests/test_site.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import unittest
 from unittest.mock import patch
+from agent.base import AgentException
 
 from agent.site import Site
 from agent.bench import Bench
@@ -102,7 +103,7 @@ class TestSite(unittest.TestCase):
         site_name = "corrupt-site.frappe.cloud"
         self._create_test_site(site_name)
         self._make_site_config(site_name, content="corrupt{}")
-        with self.assertRaises(json.decoder.JSONDecodeError):
+        with self.assertRaises(AgentException):
             bench.sites
 
     def test_sites_property_of_bench_doesnt_throw_error_for_assets_and_apps_txt(
@@ -114,7 +115,7 @@ class TestSite(unittest.TestCase):
         self._make_site_config(site_name)
         try:
             bench.sites
-        except json.decoder.JSONDecodeError:
+        except AgentException:
             self.fail(
                 "sites property of bench threw error for assets and apps.txt"
             )

--- a/agent/tests/test_site.py
+++ b/agent/tests/test_site.py
@@ -96,7 +96,7 @@ class TestSite(unittest.TestCase):
             os.path.exists(os.path.join(self.sites_directory, old_name))
         )
 
-    def test_sites_property_of_bench_throws_error_if_site_config_is_corrupt(
+    def test_valid_sites_property_of_bench_throws_error_if_site_config_is_corrupt(
         self,
     ):
         bench = self._get_test_bench()
@@ -113,9 +113,9 @@ class TestSite(unittest.TestCase):
 """,  # missing comma above
         )
         with self.assertRaises(AgentException):
-            bench.sites
+            bench.valid_sites
 
-    def test_sites_property_of_bench_doesnt_throw_error_for_assets_and_apps_txt(
+    def test_valid_sites_property_of_bench_doesnt_throw_error_for_assets_and_apps_txt(
         self,
     ):
         bench = self._get_test_bench()
@@ -130,6 +130,6 @@ class TestSite(unittest.TestCase):
             )
         self.assertEqual(len(bench.sites), 1)
         try:
-            bench.sites[site_name]
+            bench.valid_sites[site_name]
         except KeyError:
             self.fail("Site not found in bench.sites")

--- a/agent/tests/test_site.py
+++ b/agent/tests/test_site.py
@@ -102,7 +102,16 @@ class TestSite(unittest.TestCase):
         bench = self._get_test_bench()
         site_name = "corrupt-site.frappe.cloud"
         self._create_test_site(site_name)
-        self._make_site_config(site_name, content="corrupt{}")
+        self._make_site_config(
+            site_name,
+            content="""
+{
+   "db_name": "fake_db_name",
+   "db_password": "fake_db_password"
+   "some_key": "some_value"
+}
+""",  # missing comma above
+        )
         with self.assertRaises(AgentException):
             bench.sites
 


### PR DESCRIPTION
- ci: Add args to flake8 like in press for precommit
- fix(Bench): Add hack to show output in agent job
- fix(Bench): Censor sensitive keys in output
- fix(Bench): Include directory information when throwing err
![image](https://github.com/frappe/agent/assets/25403045/9d37fc94-1753-4440-b441-a9afcca5be16)

