### PR TITLE
refactor: set worker class to gthread if threads > 0

### DIFF
--- a/agent/bench.py
+++ b/agent/bench.py
@@ -577,7 +577,6 @@ class Bench(Base):
                 "environment_variables": self.bench_config.get(
                     "environment_variables"
                 ),
-                "gunicorn_worker_type": self.bench_config.get("gunicorn_worker_type"),
                 "gunicorn_threads_per_worker": self.bench_config.get("gunicorn_threads_per_worker"),
             },
             supervisor_config,

--- a/agent/templates/bench/supervisor.conf
+++ b/agent/templates/bench/supervisor.conf
@@ -5,7 +5,7 @@ environment={% for key, value in environment_variables.items() %}{{ key }}="{{ v
 {% endif %}
 
 [program:frappe-bench-frappe-web]
-command=/home/frappe/frappe-bench/env/bin/gunicorn --bind 0.0.0.0:8000 --workers {{ gunicorn_workers }} --timeout {{ http_timeout }} --graceful-timeout 30 --max-requests 5000 --max-requests-jitter 1000 --worker-tmp-dir /dev/shm frappe.app:application --preload --statsd-host={{ statsd_host }} --statsd-prefix={{ name }} {{ '--worker-class=' + gunicorn_worker_type if gunicorn_worker_type else '' }} {% if gunicorn_threads_per_worker %} --threads={{ gunicorn_threads_per_worker }}{% endif %}
+command=/home/frappe/frappe-bench/env/bin/gunicorn --bind 0.0.0.0:8000 --workers {{ gunicorn_workers }} --timeout {{ http_timeout }} --graceful-timeout 30 --max-requests 5000 --max-requests-jitter 1000 --worker-tmp-dir /dev/shm frappe.app:application --preload --statsd-host={{ statsd_host }} --statsd-prefix={{ name }} {% if gunicorn_threads_per_worker > 0 %} --worker-class=gthread --threads={{ gunicorn_threads_per_worker }}{% endif %}
 environment=FORWARDED_ALLOW_IPS="*"
 priority=4
 autostart=true


### PR DESCRIPTION
For more details check: https://github.com/frappe/press/pull/1255

Other worker types are anyways not supported, so either sync workers (0 threads) or gthread workers (>0 threads)