### PR TITLE
build: update ipython dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ grequests==0.6.0
 gunicorn==20.0.4
 honcho==1.0.1
 idna==2.8
-ipython==7.14.0
+ipython==8.12.3
 itsdangerous==1.1.0
 Jinja2==2.10.3
 MarkupSafe==1.1.1


### PR DESCRIPTION
This version is unusable and crashes while attempting to autocomplete.