### PR TITLE
fix: Set correct remote_addr

### DIFF
--- a/agent/templates/bench/nginx.conf.jinja2
+++ b/agent/templates/bench/nginx.conf.jinja2
@@ -217,7 +217,7 @@ server {
 	}
 
 	location @webserver {
-		proxy_set_header X-Forwarded-For $remote_addr;
+		proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;;
 		proxy_set_header X-Forwarded-Proto https;
 		proxy_set_header X-Frappe-Site-Name $site_name_{{ bench_name_slug }};
 		proxy_set_header Host $host;


### PR DESCRIPTION
- Proxy nginx forces remote_addr which is true IP
- App server nginx still forces remote_addr which is actually proxy
  server IP.

So proxy server shouldn't force remote_addr but instead only set it if unset.


https://github.com/frappe/agent/blob/81e30c6876e647fc5ca869d571053dd07251c202/agent/templates/proxy/nginx.conf.jinja2#L169


As per my understanding:

![image](https://github.com/frappe/agent/assets/9079960/bf99fa8c-c134-4952-ab33-55300a546dcb)
