### PR TITLE
fix: Apply limit on matching rows, not read rows

### DIFF
--- a/agent/database.py
+++ b/agent/database.py
@@ -30,7 +30,7 @@ class DatabaseServer(Server):
             f"mysqlbinlog --short-form --database {database} "
             f"--start-datetime '{start_datetime}' "
             f"--stop-datetime '{stop_datetime}' "
-            f" {log} | grep -Piv '{LINES_TO_SKIP}' | head -n {max_lines}"
+            f" {log} | grep -Piv '{LINES_TO_SKIP}'"
         )
 
         DELIMITER = "/*!*/;"
@@ -55,6 +55,8 @@ class DatabaseServer(Server):
                             ),
                         }
                     )
+                    if len(events) > max_lines:
+                        break
         return events
 
     @property


### PR DESCRIPTION
Binary log browser is unintuitive to use with filters, the "max lines"
is applied before filtering.

Since we have bounded size of bin log (100MB per file) just reading
everything which is ~= 100MB of text is fine IMO.
