### PR TITLE
feat(nginx): Add support for IPv6

### DIFF
--- a/agent/templates/agent/nginx.conf.jinja2
+++ b/agent/templates/agent/nginx.conf.jinja2
@@ -16,6 +16,7 @@ map $http_upgrade $connection_upgrade {
 
 server {
 	listen 443 ssl http2;
+	listen [::]:443 ssl http2;
 	server_name {{ name }};
 
 	ssl_certificate {{ tls_directory }}/fullchain.pem;

--- a/agent/templates/bench/nginx.conf.jinja2
+++ b/agent/templates/bench/nginx.conf.jinja2
@@ -23,6 +23,7 @@ map $host $site_name_{{ bench_name_slug }} {
 {% for site in sites + ( domains.keys() | list ) %}
 server {
 	listen 443 http2 ssl;
+	listen [::]:443 http2 ssl;
 	server_name {{ site.name or site}};
 
 	ssl_certificate {{ nginx_directory }}/hosts/{{ site.host or site }}/fullchain.pem;
@@ -145,6 +146,7 @@ server {
 
 server {
 	listen 80;
+	listen [::]:80;
 	server_name
 		{% for site in sites -%}
 			{{ site.name }}
@@ -164,6 +166,7 @@ server {
 {% else %}
 server {
 	listen 80;
+	listen [::]:80;
 
 	server_name
 		{% for site in sites -%}
@@ -270,6 +273,7 @@ server {
 {% if code_server -%}
 server {
     listen 80;
+    listen [::]:80;
 	server_name {{ code_server.name }};
 
     location / {

--- a/agent/templates/proxy/nginx.conf.jinja2
+++ b/agent/templates/proxy/nginx.conf.jinja2
@@ -76,6 +76,7 @@ proxy_cache_path /tmp/cache keys_zone=proxy_cache_zone:10m loader_threshold=300 
 
 server {
 	listen 443 http2 ssl{% if ns.host.strip("*.") == domain %} default_server{% endif %};
+	listen [::]:443 http2 ssl{% if ns.host.strip("*.") == domain %} default_server{% endif %};
 	server_name {{ ns.host }};
 
 
@@ -200,6 +201,7 @@ server {
 
 server {
 	listen 80;
+	listen [::]:80;
 	server_name _;
 
 	location ^~ /.well-known/acme-challenge/ {
@@ -213,6 +215,7 @@ server {
 
 server {
 	listen 127.0.0.1:10090;
+	listen [::1]:10090;
 	location / {
 		return 307 https://{{ domain }}/dashboard/#/sites/new?domain=$host;
 	}
@@ -220,6 +223,7 @@ server {
 
 server {
 	listen 127.0.0.1:10091;
+	listen [::1]:10091;
 
 	root {{ error_pages_directory }};
 	error_page 503 /deactivated.html;
@@ -236,6 +240,7 @@ server {
 
 server {
 	listen 127.0.0.1:10092;
+	listen [::1]:10092;
 
 	root {{ error_pages_directory }};
 	error_page 402 /suspended.html;
@@ -252,6 +257,7 @@ server {
 
 server {
 	listen 127.0.0.1:10093;
+	listen [::1]:10093;
 
 	root {{ error_pages_directory }};
 	error_page 402 /suspended_saas.html;


### PR DESCRIPTION
# Add IPv6 `listen` directives to Nginx configuration templates

I believe that agent services don't listen on IPv6 by default. This PR attempts to fix this issue by adding IPv6 specific lines to the Nginx config templates.

```conf
listen 80; 
listen [::]:80;  # this line was missing

listen 127.0.0.1:80;
listen [::1]:80;  # this line was missing
```

---

## References

https://serverfault.com/questions/638367/do-you-need-separate-ipv4-and-ipv6-listen-directives-in-nginx/638370#638370
https://serverfault.com/questions/512054/globally-setting-ipv6only-off/512213#512213
https://stackoverflow.com/questions/40189084/what-is-ipv6-for-localhost-and-0-0-0-0/40189197#40189197
https://docs.aws.amazon.com/en_us/lightsail/latest/userguide/amazon-lightsail-configure-ipv6-on-nginx.html#configure-ipv6-nginx

![image](https://github.com/frappe/agent/assets/10946971/9b09446d-e3b5-4b89-8647-0e4630dacf41)
