### PR TITLE
fix(proxy): Remove conflicting site before adding a new site

### DIFF
--- a/agent/proxy.py
+++ b/agent/proxy.py
@@ -75,11 +75,20 @@ class Proxy(Server):
 
     @job("Add Site to Upstream")
     def add_site_to_upstream_job(self, upstream, site, skip_reload=False):
+        self.remove_conflicting_site(site)
         self.add_site_to_upstream(upstream, site)
         self.generate_proxy_config()
         if skip_reload:
             return
         self.reload_nginx()
+
+    @step("Remove Conflicting Site")
+    def remove_conflicting_site(self, site):
+        # Go through all upstreams and remove the site file matching the site name
+        for upstream in self.upstreams:
+            conflict = os.path.join(self.upstreams_directory, upstream, site)
+            if os.path.exists(conflict):
+                os.remove(conflict)
 
     @step("Add Site File to Upstream Directory")
     def add_site_to_upstream(self, upstream, site):
@@ -147,6 +156,7 @@ class Proxy(Server):
         new_name: str,
         skip_reload=False,
     ):
+        self.remove_conflicting_site(new_name)
         self.rename_site_on_upstream(upstream, site, new_name)
         site_host_dir = os.path.join(self.hosts_directory, site)
         if os.path.exists(site_host_dir):


### PR DESCRIPTION
This is to avoid failures like this on add/rename site jobs

```shell
systemd[1]: Reloading A high performance web server and a reverse proxy server.
nginx[541919]: nginx: [emerg] conflicting parameter "frappemail.frappe.cloud" in /etc/nginx/conf.d/proxy.conf:3722
systemd[1]: nginx.service: Control process exited, code=exited, status=1/FAILURE
systemd[1]: Reload failed for A high performance web server and a reverse proxy server.
```

Reference: https://frappecloud.com/app/agent-job/3d4bd1ab06