### PR TITLE
fix: `from __future__ import annotations`

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from agent.cli import cli
 

--- a/agent/analytics.py
+++ b/agent/analytics.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import sys
 import traceback

--- a/agent/app.py
+++ b/agent/app.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 from agent.base import Base

--- a/agent/base.py
+++ b/agent/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 import subprocess

--- a/agent/bench.py
+++ b/agent/bench.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hashlib
 import json
 import os

--- a/agent/builder.py
+++ b/agent/builder.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import shlex
 import subprocess

--- a/agent/cli.py
+++ b/agent/cli.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 import shutil

--- a/agent/database.py
+++ b/agent/database.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from agent.server import Server
 from pathlib import Path

--- a/agent/docker_cache_utils.py
+++ b/agent/docker_cache_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # Code below copied mostly verbatim from press, this is tentative and
 # will be removed once build code has been moved out of press.
 #

--- a/agent/exceptions.py
+++ b/agent/exceptions.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class BenchNotExistsException(Exception):
     def __init__(self, bench):
         self.bench = bench

--- a/agent/job.py
+++ b/agent/job.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import json
 import traceback

--- a/agent/minio.py
+++ b/agent/minio.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from agent.job import job, step
 from agent.server import Server

--- a/agent/monitor.py
+++ b/agent/monitor.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import requests
 import tempfile

--- a/agent/patch_handler.py
+++ b/agent/patch_handler.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import importlib
 

--- a/agent/patches/__init__.py
+++ b/agent/patches/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/agent/patches/add_agent_id_field.py
+++ b/agent/patches/add_agent_id_field.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def execute():
     """add a new fc_agent_job_id field to JobModel"""
     from agent.job import agent_database as database

--- a/agent/proxy.py
+++ b/agent/proxy.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 import shutil

--- a/agent/proxysql.py
+++ b/agent/proxysql.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 from agent.job import job, step

--- a/agent/security.py
+++ b/agent/security.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 from agent.base import Base
 

--- a/agent/server.py
+++ b/agent/server.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 import shutil

--- a/agent/site.py
+++ b/agent/site.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 import re

--- a/agent/ssh.py
+++ b/agent/ssh.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import tempfile
 

--- a/agent/tests/__init__.py
+++ b/agent/tests/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/agent/tests/test_proxy.py
+++ b/agent/tests/test_proxy.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 import shutil

--- a/agent/tests/test_site.py
+++ b/agent/tests/test_site.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 import shutil

--- a/agent/usage.py
+++ b/agent/usage.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 import sys

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from math import ceil
 from typing import TYPE_CHECKING

--- a/agent/web.py
+++ b/agent/web.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import logging
 import os
@@ -459,7 +461,9 @@ def rename_site(bench, site):
     job = (
         Server()
         .benches[bench]
-        .rename_site_job(site, data["new_name"], data.get("create_user"), data.get("config"))
+        .rename_site_job(
+            site, data["new_name"], data.get("create_user"), data.get("config")
+        )
     )
     return {"job": job}
 


### PR DESCRIPTION
Fool me twice...

Fix issues caused by dumb shit like this: https://github.com/frappe/agent/commit/a9a020565cd24b0e24bf4203c1bc48100ce12c9e

Adding the line converts annotations into strings before runtime:
![example](https://github.com/user-attachments/assets/2de40193-90b9-4a9d-ac26-ee7f7782b824)
