### PR TITLE
feat: db users and permission manager

### DIFF
--- a/agent/database.py
+++ b/agent/database.py
@@ -40,9 +40,10 @@ class Database:
     """
 
     def add_user(self, username: str, password: str):
-        query = f"""CREATE OR REPLACE USER '{username}'@'%' IDENTIFIED BY '{password}';
-FLUSH PRIVILEGES;
-"""
+        query = f"""
+            CREATE OR REPLACE USER '{username}'@'%' IDENTIFIED BY '{password}';
+            FLUSH PRIVILEGES;
+        """
         self._run_sql(
             query,
             commit=True,
@@ -51,9 +52,9 @@ FLUSH PRIVILEGES;
     def remove_user(self, username: str):
         self._run_sql(
             f"""
-                      DROP USER IF EXISTS '{username}'@'%';
-                      FLUSH PRIVILEGES;
-                      """,
+                DROP USER IF EXISTS '{username}'@'%';
+                FLUSH PRIVILEGES;
+            """,
             commit=True,
         )
 
@@ -139,6 +140,8 @@ FLUSH PRIVILEGES;
                         f"GRANT {privilege} {columns} ON `{self.database_name}`.`{table_name}` TO `{username}`@`%`;"  # noqa: E501
                     )
                 else:
+                    # while usisng column level privileges `ALL` doesnt work
+                    # So we need to provide all possible privileges for that columns
                     for p in ["SELECT", "INSERT", "UPDATE", "REFERENCES"]:
                         queries.append(
                             f"GRANT {p} {columns} ON `{self.database_name}`.`{table_name}` TO `{username}`@`%`;"  # noqa: E501

--- a/agent/database.py
+++ b/agent/database.py
@@ -36,7 +36,7 @@ class Database:
     NOTE: These methods require root access to the database
     - create_user
     - remove_user
-    - modify_user_access
+    - modify_user_permissions
     """
 
     def create_user(self, username: str, password: str):

--- a/agent/database.py
+++ b/agent/database.py
@@ -33,10 +33,10 @@ class Database:
             )
 
     """
-    NOTE: These methods requires root access to the database
+    NOTE: These methods require root access to the database
     - add_user
     - remove_user
-    - modify_access
+    - modify_user_access
     """
 
     def add_user(self, username: str, password: str):

--- a/agent/site.py
+++ b/agent/site.py
@@ -287,7 +287,12 @@ class Site(Base):
         self.db_instance("root", mariadb_root_password).remove_user(user)
         return {}
 
-    def modify_permissions_for_database_user(self, user, mode, permissions, mariadb_root_password):
+    @job("Modify Database User Permissions", priority="high")
+    def modify_database_user_permissions_job(self, user, mode, permissions, mariadb_root_password):
+        return self.modify_database_user_permissions(user, mode, permissions, mariadb_root_password)
+
+    @step("Modify Database User Permissions")
+    def modify_database_user_permissions(self, user, mode, permissions, mariadb_root_password):
         if user == self.user:
             # Do not perform any operation for the main user
             return {}

--- a/agent/tests/test_database.py
+++ b/agent/tests/test_database.py
@@ -348,7 +348,8 @@ class TestDatabase(unittest.TestCase):
                 },
             )
         except Exception:
-            print("Failed query: ", db.last_executed_query)
+            if hasattr(db, "last_executed_query"):
+                print("Failed query: ", db.last_executed_query)
             raise
 
         # verify access for `Person` table
@@ -395,7 +396,8 @@ class TestDatabase(unittest.TestCase):
                 "user1", "granular", permissions={"Person": {"mode": "read_only", "columns": ["id"]}}
             )
         except Exception:
-            print("Failed query: ", db.last_executed_query)
+            if hasattr(db, "last_executed_query"):
+                print("Failed query: ", db.last_executed_query)
             raise
 
         # verify access for `Person` table
@@ -413,7 +415,8 @@ class TestDatabase(unittest.TestCase):
                 "user1", "granular", permissions={"Person": {"mode": "read_write", "columns": ["id"]}}
             )
         except Exception:
-            print("Failed query: ", db.last_executed_query)
+            if hasattr(db, "last_executed_query"):
+                print("Failed query: ", db.last_executed_query)
             raise
 
         # verify access for `Person` table

--- a/agent/tests/test_database.py
+++ b/agent/tests/test_database.py
@@ -247,12 +247,12 @@ class TestDatabase(unittest.TestCase):
         )
         self.assertEqual(data[0]["row_count"], 0)
 
-    def test_add_user(self):
+    def test_create_user(self):
         db = self._db(self.db1__name, "root", self.instance.db_root_password)
 
-        # add user
+        # create user
         try:
-            db.add_user("test_user", "test_user_password")
+            db.create_user("test_user", "test_user_password")
         except:
             print(f"Failed query: {db.query}")
             raise
@@ -269,7 +269,7 @@ class TestDatabase(unittest.TestCase):
         db = self._db(self.db1__name, "root", self.instance.db_root_password)
 
         # add a dummy user
-        db.add_user("test_user", "test_user_password")
+        db.create_user("test_user", "test_user_password")
 
         # remove user
         try:
@@ -288,7 +288,7 @@ class TestDatabase(unittest.TestCase):
 
     def test_create_read_only_permission(self):
         db = self._db(self.db1__name, "root", self.instance.db_root_password)
-        db.add_user("user1", "test_password")  # add user
+        db.create_user("user1", "test_password")  # create user
 
         user1_db = self._db(self.db1__name, "user1", "test_password")
 
@@ -297,7 +297,7 @@ class TestDatabase(unittest.TestCase):
         self.assertFalse(success, "User `user1` should not have access to the database")
         self.assertIn("Access denied for user", str(output))
 
-        db.modify_user_permission("user1", "read_only")
+        db.modify_user_permissions("user1", "read_only")
 
         # try to access the database again
         success, output = user1_db.execute_query("SELECT * FROM Person;")
@@ -311,7 +311,7 @@ class TestDatabase(unittest.TestCase):
 
     def test_create_read_write_permission(self):
         db = self._db(self.db1__name, "root", self.instance.db_root_password)
-        db.add_user("user1", "test_password")  # add user
+        db.create_user("user1", "test_password")  # create user
 
         user1_db = self._db(self.db1__name, "user1", "test_password")
 
@@ -320,7 +320,7 @@ class TestDatabase(unittest.TestCase):
         self.assertFalse(success, "User `user1` should not have access to the database")
         self.assertIn("Access denied for user", str(output))
 
-        db.modify_user_permission("user1", "read_write")
+        db.modify_user_permissions("user1", "read_write")
 
         # try to access the database again
         success, output = user1_db.execute_query("SELECT * FROM Person;")
@@ -335,11 +335,11 @@ class TestDatabase(unittest.TestCase):
         db = self._db(self.db1__name, "root", self.instance.db_root_password)
         user1_db = self._db(self.db1__name, "user1", "test_password")
 
-        db.add_user("user1", "test_password")  # add user
+        db.create_user("user1", "test_password")  # create user
 
         # modify access
         try:
-            db.modify_user_permission(
+            db.modify_user_permissions(
                 "user1",
                 "granular",
                 permissions={
@@ -375,7 +375,7 @@ class TestDatabase(unittest.TestCase):
         self.assertIn("SELECT command denied to user", str(output))
 
         # purge access and verify
-        db.modify_user_permission("user1", "granular", permissions={})
+        db.modify_user_permissions("user1", "granular", permissions={})
 
         success, output = user1_db.execute_query("SELECT * FROM Person;")
         self.assertFalse(success, "User `user1` should not have access to `Person` table")
@@ -388,11 +388,11 @@ class TestDatabase(unittest.TestCase):
         db = self._db(self.db1__name, "root", self.instance.db_root_password)
         user1_db = self._db(self.db1__name, "user1", "test_password")
 
-        db.add_user("user1", "test_password")  # add user
+        db.create_user("user1", "test_password")  # create user
 
         # modify access [read_only]
         try:
-            db.modify_user_permission(
+            db.modify_user_permissions(
                 "user1", "granular", permissions={"Person": {"mode": "read_only", "columns": ["id"]}}
             )
         except Exception:
@@ -411,7 +411,7 @@ class TestDatabase(unittest.TestCase):
 
         # modify access [read_write]
         try:
-            db.modify_user_permission(
+            db.modify_user_permissions(
                 "user1", "granular", permissions={"Person": {"mode": "read_write", "columns": ["id"]}}
             )
         except Exception:
@@ -445,8 +445,8 @@ class TestDatabase(unittest.TestCase):
 
     def test_revoke_permission(self):
         db = self._db(self.db1__name, "root", self.instance.db_root_password)
-        db.add_user("user1", "test_password")  # add user
-        db.modify_user_permission("user1", "read_only")
+        db.create_user("user1", "test_password")  # create user
+        db.modify_user_permissions("user1", "read_only")
 
         user1_db = self._db(self.db1__name, "user1", "test_password")
 
@@ -456,7 +456,7 @@ class TestDatabase(unittest.TestCase):
 
         # revoke permission
         # setting no permission in granular mode, will revoke all existing permissions
-        db.modify_user_permission("user1", "granular", permissions={})
+        db.modify_user_permissions("user1", "granular", permissions={})
 
         # try to access the database again
         success, output = user1_db.execute_query("SELECT * FROM Person;")

--- a/agent/tests/test_database.py
+++ b/agent/tests/test_database.py
@@ -100,6 +100,24 @@ class TestDatabase(unittest.TestCase):
         INSERT INTO Person (id, name) VALUES (3, "Alice Johnson");
         INSERT INTO Person (id, name) VALUES (4, "Bob Brown");
         INSERT INTO Person (id, name) VALUES (5, "Charlie Davis");
+        CREATE TABLE Product (
+            id int,
+            name varchar(255)
+        );
+        INSERT INTO Product (id, name) VALUES (1, "Book");
+        INSERT INTO Product (id, name) VALUES (2, "Car");
+        INSERT INTO Product (id, name) VALUES (3, "House");
+        INSERT INTO Product (id, name) VALUES (4, "Computer");
+        INSERT INTO Product (id, name) VALUES (5, "Table");
+        CREATE TABLE Account (
+            id int,
+            name varchar(255)
+        );
+        INSERT INTO Account (id, name) VALUES (1, "John Doe");
+        INSERT INTO Account (id, name) VALUES (2, "Jane Smith");
+        INSERT INTO Account (id, name) VALUES (3, "Alice Johnson");
+        INSERT INTO Account (id, name) VALUES (4, "Bob Brown");
+        INSERT INTO Account (id, name) VALUES (5, "Charlie Davis");
         """,
             commit=True,
             as_dict=True,
@@ -279,7 +297,7 @@ class TestDatabase(unittest.TestCase):
         self.assertFalse(success, "User `user1` should not have access to the database")
         self.assertIn("Access denied for user", str(output))
 
-        db.modify_user_access("user1", "read_only")
+        db.modify_user_permission("user1", "read_only")
 
         # try to access the database again
         success, output = user1_db.execute_query("SELECT * FROM Person;")
@@ -302,7 +320,7 @@ class TestDatabase(unittest.TestCase):
         self.assertFalse(success, "User `user1` should not have access to the database")
         self.assertIn("Access denied for user", str(output))
 
-        db.modify_user_access("user1", "read_write")
+        db.modify_user_permission("user1", "read_write")
 
         # try to access the database again
         success, output = user1_db.execute_query("SELECT * FROM Person;")
@@ -312,3 +330,132 @@ class TestDatabase(unittest.TestCase):
         # user should have write access
         success, _ = user1_db.execute_query('INSERT INTO Person (id, name) VALUES (10, "Test Person");')
         self.assertTrue(success, "User `user1` should have write access to the database")
+
+    def test_granular_permission_table_level(self):
+        db = self._db(self.db1__name, "root", self.instance.db_root_password)
+        user1_db = self._db(self.db1__name, "user1", "test_password")
+
+        db.add_user("user1", "test_password")  # add user
+
+        # modify access
+        try:
+            db.modify_user_permission(
+                "user1",
+                "granular",
+                permissions={
+                    "Person": {"mode": "read_only", "columns": "*"},
+                    "Product": {"mode": "read_write", "columns": "*"},
+                },
+            )
+        except Exception:
+            print("Failed query: ", db.last_executed_query)
+            raise
+
+        # verify access for `Person` table
+        success, output = user1_db.execute_query("SELECT * FROM Person;")
+        self.assertTrue(success, "User `user1` should have read access to `Person` table")
+        self.assertGreater(len(output), 0)
+
+        success, output = user1_db.execute_query('INSERT INTO Person (id, name) VALUES (10, "Test Person");')
+        self.assertFalse(success, "User `user1` should not have write access to `Person` table")
+        self.assertIn("INSERT command denied to user", str(output))
+
+        # verify access for `Product` table
+        success, output = user1_db.execute_query("SELECT * FROM Product;")
+        self.assertTrue(success, "User `user1` should have read access to `Product` table")
+        self.assertGreater(len(output), 0)
+
+        success, _ = user1_db.execute_query('INSERT INTO Product (id, name) VALUES (10, "Test Product");')
+        self.assertTrue(success, "User `user1` should have write access to `Product` table")
+
+        # verify access for `Account` table
+        success, output = user1_db.execute_query("SELECT * FROM Account;")
+        self.assertFalse(success, "User `user1` should not have access to `Account` table")
+        self.assertIn("SELECT command denied to user", str(output))
+
+        # purge access and verify
+        db.modify_user_permission("user1", "granular", permissions={})
+
+        success, output = user1_db.execute_query("SELECT * FROM Person;")
+        self.assertFalse(success, "User `user1` should not have access to `Person` table")
+        success, output = user1_db.execute_query("SELECT * FROM Product;")
+        self.assertFalse(success, "User `user1` should not have access to `Product` table")
+        success, output = user1_db.execute_query("SELECT * FROM Account;")
+        self.assertFalse(success, "User `user1` should not have access to `Account` table")
+
+    def test_granular_permission_column_level(self):
+        db = self._db(self.db1__name, "root", self.instance.db_root_password)
+        user1_db = self._db(self.db1__name, "user1", "test_password")
+
+        db.add_user("user1", "test_password")  # add user
+
+        # modify access [read_only]
+        try:
+            db.modify_user_permission(
+                "user1", "granular", permissions={"Person": {"mode": "read_only", "columns": ["id"]}}
+            )
+        except Exception:
+            print("Failed query: ", db.last_executed_query)
+            raise
+
+        # verify access for `Person` table
+        success, output = user1_db.execute_query("SELECT * FROM Person;")
+        self.assertFalse(success, "User `user1` should not have read access to all columns of `Person` table")
+        self.assertIn("SELECT command denied to user", str(output))
+
+        success, output = user1_db.execute_query("SELECT id FROM Person;")
+        self.assertTrue(success, "User `user1` should have read access to `id` column of `Person` table")
+        self.assertGreater(len(output), 0)
+
+        # modify access [read_write]
+        try:
+            db.modify_user_permission(
+                "user1", "granular", permissions={"Person": {"mode": "read_write", "columns": ["id"]}}
+            )
+        except Exception:
+            print("Failed query: ", db.last_executed_query)
+            raise
+
+        # verify access for `Person` table
+        success, output = user1_db.execute_query("SELECT * FROM Person;")
+        self.assertFalse(success, "User `user1` should not have read access to all columns of `Person` table")
+        self.assertIn("SELECT command denied to user", str(output))
+
+        success, output = user1_db.execute_query("SELECT id FROM Person;")
+        self.assertTrue(success, "User `user1` should have read access to `id` column of `Person` table")
+        self.assertGreater(len(output), 0)
+
+        success, output = user1_db.execute_query("UPDATE Person SET name = 'Columbia' WHERE id = 1;")
+        self.assertFalse(success, "User `user1` should have write access to `name` col of `Person` table")
+        self.assertIn("UPDATE command denied to user", str(output))
+
+        success, output = user1_db.execute_query("UPDATE Person SET id = 2 WHERE name = 'Columbia';")
+        self.assertFalse(success, "User `user1` should have write access to `id` col of `Person` table")
+        self.assertIn("SELECT command denied to user", str(output))
+
+        success, output = user1_db.execute_query("UPDATE Person SET id = 50 WHERE id = 1;")
+        self.assertTrue(success, "User `user1` should have write access to `id` col of `Person` table")
+
+        success, output = user1_db.execute_query("DELETE FROM Person WHERE id = 2;")
+        self.assertFalse(success, "User `user1` should have write access to `id` col of `Person` table")
+        self.assertIn("DELETE command denied to user", str(output))
+
+    def test_revoke_permission(self):
+        db = self._db(self.db1__name, "root", self.instance.db_root_password)
+        db.add_user("user1", "test_password")  # add user
+        db.modify_user_permission("user1", "read_only")
+
+        user1_db = self._db(self.db1__name, "user1", "test_password")
+
+        # try to access the database
+        success, _ = user1_db.execute_query("SELECT * FROM Person;")
+        self.assertTrue(success, "User `user1` should have read access to the database")
+
+        # revoke permission
+        # setting no permission in granular mode, will revoke all existing permissions
+        db.modify_user_permission("user1", "granular", permissions={})
+
+        # try to access the database again
+        success, output = user1_db.execute_query("SELECT * FROM Person;")
+        self.assertFalse(success, "User `user1` should not have access to the database")
+        self.assertIn("Access denied for user", str(output))

--- a/agent/web.py
+++ b/agent/web.py
@@ -572,6 +572,44 @@ def run_sql(bench, site):
     )
 
 
+@application.route("/benches/<string:bench>/sites/<string:site>/database/users", methods=["POST"])
+@validate_bench_and_site
+def add_database_user(bench, site):
+    data = request.json
+    return (
+        Server()
+        .benches[bench]
+        .sites[site]
+        .create_database_user(data["user"], data["password"], data["mariadb_root_password"])
+    )
+
+
+@application.route(
+    "/benches/<string:bench>/sites/<string:site>/database/users/<string:db_user>", methods=["DELETE"]
+)
+@validate_bench_and_site
+def remove_database_user(bench, site, db_user):
+    data = request.json
+    return Server().benches[bench].sites[site].remove_database_user(db_user, data["mariadb_root_password"])
+
+
+@application.route(
+    "/benches/<string:bench>/sites/<string:site>/database/users/<string:db_user>/permissions",
+    methods=["POST"],
+)
+@validate_bench_and_site
+def add_database_permissions(bench, site, db_user):
+    data = request.json
+    return (
+        Server()
+        .benches[bench]
+        .sites[site]
+        .modify_permissions_for_database_user(
+            db_user, data["mode"], data.get("permissions", []), data["mariadb_root_password"]
+        )
+    )
+
+
 @application.route(
     "/benches/<string:bench>/sites/<string:site>/migrate",
     methods=["POST"],

--- a/agent/web.py
+++ b/agent/web.py
@@ -600,16 +600,17 @@ def remove_database_user(bench, site, db_user):
     methods=["POST"],
 )
 @validate_bench_and_site
-def add_database_permissions(bench, site, db_user):
+def update_database_permissions(bench, site, db_user):
     data = request.json
-    return (
+    job = (
         Server()
         .benches[bench]
         .sites[site]
-        .modify_permissions_for_database_user(
+        .modify_database_user_permissions_job(
             db_user, data["mode"], data.get("permissions", []), data["mariadb_root_password"]
         )
     )
+    return {"job": job}
 
 
 @application.route(

--- a/agent/web.py
+++ b/agent/web.py
@@ -574,14 +574,15 @@ def run_sql(bench, site):
 
 @application.route("/benches/<string:bench>/sites/<string:site>/database/users", methods=["POST"])
 @validate_bench_and_site
-def add_database_user(bench, site):
+def create_database_user(bench, site):
     data = request.json
-    return (
+    job = (
         Server()
         .benches[bench]
         .sites[site]
-        .create_database_user(data["user"], data["password"], data["mariadb_root_password"])
+        .create_database_user_job(data["username"], data["password"], data["mariadb_root_password"])
     )
+    return {"job": job}
 
 
 @application.route(
@@ -590,7 +591,8 @@ def add_database_user(bench, site):
 @validate_bench_and_site
 def remove_database_user(bench, site, db_user):
     data = request.json
-    return Server().benches[bench].sites[site].remove_database_user(db_user, data["mariadb_root_password"])
+    job = Server().benches[bench].sites[site].remove_database_user_job(db_user, data["mariadb_root_password"])
+    return {"job": job}
 
 
 @application.route(

--- a/agent/web.py
+++ b/agent/web.py
@@ -607,7 +607,7 @@ def update_database_permissions(bench, site, db_user):
         .benches[bench]
         .sites[site]
         .modify_database_user_permissions_job(
-            db_user, data["mode"], data.get("permissions", []), data["mariadb_root_password"]
+            db_user, data["mode"], data.get("permissions", {}), data["mariadb_root_password"]
         )
     )
     return {"job": job}


### PR DESCRIPTION
Fixes https://github.com/frappe/press/issues/2237

---

- [x] Core functions
  - [x] Add User
  - [x] Remove User
  - [x] Apply permissions in bulk
  - [x] Option to provide read-only/read-write permission to all tables of a database
  - [x] Option to provide granular permission to specific tables to certain user (so that we can grant access of some specific table to a particular user)
  - [x] Testcases
- [x] Agent Job and API