### PR TITLE
feat: show hash of downloaded backup files on restore failure

### DIFF
--- a/agent/site.py
+++ b/agent/site.py
@@ -133,14 +133,19 @@ class Site(Base):
     def calculate_checksum_of_backup_files(self, database_file, public_file, private_file):
         database_file_sha256 = compute_file_hash(database_file, algorithm="sha256", raise_exception=False)
 
-        data = "SHA256 File Checksums\n\n"
-        data += f"Database File > {database_file_sha256}"
+        data = f"""Database File
+> File Name - {os.path.basename(database_file)}
+> SHA256 Checksum - {database_file_sha256}\n"""
         if public_file:
             public_file_sha256 = compute_file_hash(public_file, algorithm="sha256", raise_exception=False)
-            data += f"\nPublic File > {public_file_sha256}"
+            data += f"""\nPublic File
+> File Name - {os.path.basename(public_file)}
+> SHA256 Checksum - {public_file_sha256}\n"""
         if private_file:
             private_file_sha256 = compute_file_hash(private_file, algorithm="sha256", raise_exception=False)
-            data += f"\nPrivate File > {private_file_sha256}"
+            data += f"""\nPrivate File
+> File Name - {os.path.basename(private_file)}
+> SHA256 Checksum - {private_file_sha256}\n"""
 
         return {"output": data}
 

--- a/agent/site.py
+++ b/agent/site.py
@@ -132,14 +132,14 @@ class Site(Base):
     @step("Checksum of Downloaded Backup Files")
     def calculate_checksum_of_backup_files(self, database_file, public_file, private_file):
         database_file_sha256 = compute_file_hash(database_file, algorithm="sha256", raise_exception=False)
-        public_file_sha256 = compute_file_hash(public_file, algorithm="sha256", raise_exception=False)
-        private_file_sha256 = compute_file_hash(private_file, algorithm="sha256", raise_exception=False)
 
         data = "SHA256 File Checksums\n\n"
         data += f"Database File > {database_file_sha256}"
         if public_file:
+            public_file_sha256 = compute_file_hash(public_file, algorithm="sha256", raise_exception=False)
             data += f"\nPublic File > {public_file_sha256}"
         if private_file:
+            private_file_sha256 = compute_file_hash(private_file, algorithm="sha256", raise_exception=False)
             data += f"\nPrivate File > {private_file_sha256}"
 
         return {"output": data}

--- a/agent/site.py
+++ b/agent/site.py
@@ -173,7 +173,6 @@ class Site(Base):
             self.calculate_checksum_of_backup_files(files["database"], files["public"], files["private"])
             raise
         finally:
-            pass
             self.bench.delete_downloaded_files(files["directory"])
         self.uninstall_unavailable_apps(apps)
         self.migrate(skip_failing_patches=skip_failing_patches)

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -130,7 +130,11 @@ def compute_file_hash(file_path, algorithm="sha256", raise_exception=True):
                 hash_func.update(chunk)
 
         return hash_func.hexdigest()
+    except FileNotFoundError:
+        if raise_exception:
+            raise
+        return "File does not exist"
     except Exception:
         if raise_exception:
             raise
-        return "FAILED"
+        return "Failed to compute hash"

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import os
 from datetime import datetime, timedelta
 from math import ceil
@@ -116,3 +117,15 @@ def end_execution(
     res["status"] = status or "Success"
     res["output"] = output or res["output"]
     return res
+
+
+def compute_file_hash(file_path, algorithm="sha256"):
+    """Compute the hash of a file using the specified algorithm."""
+    hash_func = hashlib.new(algorithm)
+
+    with open(file_path, "rb") as file:
+        # read in 10MB chunks
+        while chunk := file.read(10000000):
+            hash_func.update(chunk)
+
+    return hash_func.hexdigest()

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -119,13 +119,18 @@ def end_execution(
     return res
 
 
-def compute_file_hash(file_path, algorithm="sha256"):
-    """Compute the hash of a file using the specified algorithm."""
-    hash_func = hashlib.new(algorithm)
+def compute_file_hash(file_path, algorithm="sha256", raise_exception=True):
+    try:
+        """Compute the hash of a file using the specified algorithm."""
+        hash_func = hashlib.new(algorithm)
 
-    with open(file_path, "rb") as file:
-        # read in 10MB chunks
-        while chunk := file.read(10000000):
-            hash_func.update(chunk)
+        with open(file_path, "rb") as file:
+            # read in 10MB chunks
+            while chunk := file.read(10000000):
+                hash_func.update(chunk)
 
-    return hash_func.hexdigest()
+        return hash_func.hexdigest()
+    except Exception:
+        if raise_exception:
+            raise
+        return "FAILED"


### PR DESCRIPTION
Fixes https://github.com/frappe/press/issues/2262

It will log filename and SHA256 checksum of
- Database File
- Private File [If exists]
- Public File [If exists]

If `Site Resore` fails, sha256 checksum will be calculated and logged in agent job. 
![Screenshot 2024-11-27 at 5 36 10 PM](https://github.com/user-attachments/assets/cd78b0a0-7ef8-468d-a6a8-dbaa2a66375d)


If `Site Restore` is successful, it will not calculate checksum of file
![Screenshot 2024-11-27 at 5 02 52 PM](https://github.com/user-attachments/assets/08ff7942-32c3-4da7-8edd-847bc4df8209)
