### PR TITLE
feat(exporter): Add endpoint for RQ metrics

### DIFF
--- a/agent/bench.py
+++ b/agent/bench.py
@@ -694,6 +694,9 @@ class Bench(Base):
             ssh_port = self.bench_config.get("ssh_port", self.bench_config["web_port"] + 4000)
             ssh_ip = self.bench_config.get("private_ip", "127.0.0.1")
 
+            rq_port = self.bench_config.get("rq_port")
+            rq_port_mapping = f"-p 127.0.0.1:{rq_port}:11000 "
+
             bench_directory = "/home/frappe/frappe-bench"
             mounts = self.prepare_mounts_on_host(bench_directory)
 
@@ -703,6 +706,7 @@ class Bench(Base):
                 f"-p 127.0.0.1:{self.bench_config['web_port']}:8000 "
                 f"-p 127.0.0.1:{self.bench_config['socketio_port']}:9000 "
                 f"-p 127.0.0.1:{self.bench_config['codeserver_port']}:8088 "
+                f"{rq_port_mapping if rq_port else ''}"
                 f"-p {ssh_ip}:{ssh_port}:2200 "
                 f"-v {self.sites_directory}:{bench_directory}/sites "
                 f"-v {self.logs_directory}:{bench_directory}/logs "

--- a/agent/exporter.py
+++ b/agent/exporter.py
@@ -1,0 +1,109 @@
+from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
+from prometheus_client.registry import Collector
+from redis import Redis
+from rq import Queue, Worker
+from rq.job import JobStatus
+
+
+def get_metrics(name: str, port: int):
+    from prometheus_client.exposition import generate_latest
+
+    return generate_latest(RQCollector(name, port))
+
+
+def get_workers_stats(connection: Redis):
+    workers = Worker.all(connection=connection)
+
+    return [
+        {
+            "name": w.name,
+            "queues": w.queue_names(),
+            "state": w.get_state(),
+            "successful_job_count": w.successful_job_count,
+            "failed_job_count": w.failed_job_count,
+            "total_working_time": w.total_working_time,
+        }
+        for w in workers
+    ]
+
+
+def get_jobs_by_queue(connection: Redis):
+    return {
+        queue.name: {
+            JobStatus.QUEUED: queue.count,
+            JobStatus.STARTED: queue.started_job_registry.count,
+            JobStatus.FINISHED: queue.finished_job_registry.count,
+            JobStatus.FAILED: queue.failed_job_registry.count,
+            JobStatus.DEFERRED: queue.deferred_job_registry.count,
+            JobStatus.SCHEDULED: queue.scheduled_job_registry.count,
+        }
+        for queue in Queue.all(connection=connection)
+    }
+
+
+class RQCollector(Collector):
+    def __init__(self, name: str, port: int):
+        self.name = name
+        self.port = port
+        self.conn = Redis(port=port)
+        super().__init__()
+
+    def collect(self):
+        rq_workers = GaugeMetricFamily(
+            "rq_workers",
+            "RQ workers",
+            labels=["bench", "name", "state", "queues"],
+        )
+        rq_workers_success = CounterMetricFamily(
+            "rq_workers_success",
+            "RQ workers success count",
+            labels=["bench", "name", "queues"],
+        )
+        rq_workers_failed = CounterMetricFamily(
+            "rq_workers_failed",
+            "RQ workers fail count",
+            labels=["bench", "name", "queues"],
+        )
+        rq_workers_working_time = CounterMetricFamily(
+            "rq_workers_working_time",
+            "RQ workers spent seconds",
+            labels=["bench", "name", "queues"],
+        )
+
+        rq_jobs = GaugeMetricFamily("rq_jobs", "RQ jobs by state", labels=["bench", "queue", "status"])
+
+        workers = get_workers_stats(self.conn)
+        for worker in workers:
+            label_queues = ",".join(worker["queues"])
+            rq_workers.add_metric(
+                [
+                    self.name,
+                    worker["name"],
+                    worker["state"],
+                    label_queues,
+                ],
+                1,
+            )
+            rq_workers_success.add_metric(
+                [self.name, worker["name"], label_queues],
+                worker["successful_job_count"],
+            )
+            rq_workers_failed.add_metric(
+                [self.name, worker["name"], label_queues],
+                worker["failed_job_count"],
+            )
+            rq_workers_working_time.add_metric(
+                [self.name, worker["name"], label_queues],
+                worker["total_working_time"],
+            )
+
+        yield rq_workers
+        yield rq_workers_success
+        yield rq_workers_failed
+        yield rq_workers_working_time
+
+        for queue_name, jobs in get_jobs_by_queue(self.conn).items():
+            for status, count in jobs.items():
+                rq_jobs.add_metric([self.name, queue_name, status], count)
+
+        yield rq_jobs

--- a/agent/templates/agent/nginx.conf.jinja2
+++ b/agent/templates/agent/nginx.conf.jinja2
@@ -59,6 +59,10 @@ server {
 		proxy_set_header X-Forwarded-Host $host;
 		proxy_set_header X-Forwarded-Port $server_port;
 
+		location /agent/benches/metrics {
+			return 301 /metrics/rq;
+		}
+
 		proxy_pass http://127.0.0.1:{{ web_port }}/;
 	}
 
@@ -133,6 +137,10 @@ server {
 
 		location /metrics/elasticsearch {
 			proxy_pass http://127.0.0.1:9114/metrics;
+		}
+
+		location /metrics/rq {
+			proxy_pass http://127.0.0.1:{{ web_port }}/benches/metrics;
 		}
 
 	}

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ Jinja2==2.10.3
 MarkupSafe==1.1.1
 passlib==1.7.2
 peewee==3.13.1
+prometheus_client==0.20.0
 PyMySQL==0.9.3
 python-crontab==2.5.1
 python-dateutil==2.8.2


### PR DESCRIPTION
Closes frappe/press#1283
- Adds endpoint to fetch RQ metrics for all benches on server
- Adds endpoint to fetch RQ metrics per bench
- Exempts all benches endpoint from token validation	
	- Will be proxying this through nginx metrics endpoints and that has it's own validation setup
	- Force redirect the agent endpoint to nginx one

~~TODO~~:
	- Add to `nginx.conf`
```
		location /agent/benches/metrics {
			return 301 /metrics/rq;
		}
```
```
		location /metrics/rq {
			proxy_pass http://127.0.0.1:25052/benches/metrics;
		}
```