### PR TITLE
fix(rq): Use rq job status for timed-out and killed jobs

### DIFF
--- a/agent/job.py
+++ b/agent/job.py
@@ -172,6 +172,7 @@ def job(name: str, priority="default"):
             kwargs=kwargs,
             timeout=4 * 3600,
             result_ttl=24 * 3600,
+            job_id=str(instance.job_record.model.id),
         )
         return instance.job_record.model.id
 


### PR DESCRIPTION
Jobs that timeout, or are forcefully killed never log the status to JobModel.

If rq status is terminal and JobModel.status is non-terminal. Then treat rq status as the ground-truth

Closes https://github.com/frappe/agent/issues/101