### PR TITLE
perf: Add aggresive cache-control headers for files and assets

### DIFF
--- a/agent/templates/bench/nginx.conf.jinja2
+++ b/agent/templates/bench/nginx.conf.jinja2
@@ -84,6 +84,12 @@ server {
 
 		location ~* ^/files/.*.(htm|html|svg|xml) {
 			add_header Content-disposition "attachment";
+			add_header Cache-Control "max-age=3600,stale-while-revalidate=86400";
+			try_files /$site_name_{{ bench_name_slug }}/public/$uri @webserver;
+		}
+
+		location ~* ^/files/.*.(png|jpe?g|gif|css|js|mp3|wav|ogg|flac|avi|mov|mp4|m4v|mkv|webm) {
+			add_header Cache-Control "max-age=3600,stale-while-revalidate=86400";
 			try_files /$site_name_{{ bench_name_slug }}/public/$uri @webserver;
 		}
 
@@ -211,6 +217,12 @@ server {
 
 		location ~* ^/files/.*.(htm|html|svg|xml) {
 			add_header Content-disposition "attachment";
+			add_header Cache-Control "max-age=3600,stale-while-revalidate=86400";
+			try_files /$site_name_{{ bench_name_slug }}/public/$uri @webserver;
+		}
+
+		location ~* ^/files/.*.(png|jpe?g|gif|css|js|mp3|wav|ogg|flac|avi|mov|mp4|m4v|mkv|webm) {
+			add_header Cache-Control "max-age=3600,stale-while-revalidate=86400";
 			try_files /$site_name_{{ bench_name_slug }}/public/$uri @webserver;
 		}
 

--- a/agent/templates/bench/nginx.conf.jinja2
+++ b/agent/templates/bench/nginx.conf.jinja2
@@ -57,6 +57,7 @@ server {
 
 	location /assets {
 		try_files $uri =404;
+		add_header Cache-Control "max-age=31536000, immutable";
 	}
 
 	location ~ ^/protected/(.*) {
@@ -183,7 +184,7 @@ server {
 
 	location /assets {
 		try_files $uri =404;
-		add_header Cache-Control "max-age=31536000";
+		add_header Cache-Control "max-age=31536000, immutable";
 	}
 
 	location ~ ^/protected/(.*) {


### PR DESCRIPTION
1. Make `/assets` cache immutable, they have hashes anyway.
2. Add cache headers to typically cacheable files like images and media `/files/*` (copied the list from press)
3. Private files via framework: https://github.com/frappe/frappe/pull/29221 

In the worst case, `ctrl+shift+r` fixes any kind of stale cache anyway because they send `no-cache` header to the server. `/files/*` also have etag so even after invalidation it will just be refreshed using the etag.


The numbers are still not _that_ aggressive but they are better than 0, we can increase over time if we don't see any issue. 