### PR TITLE
perf: optimize for gthread

### DIFF
--- a/agent/templates/bench/supervisor.conf
+++ b/agent/templates/bench/supervisor.conf
@@ -5,7 +5,7 @@ environment={% for key, value in environment_variables.items() %}{{ key }}="{{ v
 {% endif %}
 
 [program:frappe-bench-frappe-web]
-command=/home/frappe/frappe-bench/env/bin/gunicorn --bind 0.0.0.0:8000 --workers {{ gunicorn_workers }} --timeout {{ http_timeout }} --graceful-timeout 30 --max-requests 5000 --max-requests-jitter 1000 --worker-tmp-dir /dev/shm frappe.app:application --preload --statsd-host={{ statsd_host }} --statsd-prefix={{ name }} {% if gunicorn_threads_per_worker > 0 %} --worker-class=gthread --threads={{ gunicorn_threads_per_worker }}{% endif %}
+command=/home/frappe/frappe-bench/env/bin/gunicorn --bind 0.0.0.0:8000 --workers {{ gunicorn_workers }} --timeout {{ http_timeout }} --graceful-timeout 30 --max-requests 5000 --max-requests-jitter 1000 --worker-tmp-dir /dev/shm frappe.app:application --preload --statsd-host={{ statsd_host }} --statsd-prefix={{ name }} {% if gunicorn_threads_per_worker > 0 %} --worker-class=gthread --threads={{ gunicorn_threads_per_worker }}{% endif %} --reuse-port --worker-connections={{ (gunicorn_threads_per_worker + 1) * 2 }}
 environment=FORWARDED_ALLOW_IPS="*"
 priority=4
 autostart=true

--- a/agent/templates/bench/supervisor.conf
+++ b/agent/templates/bench/supervisor.conf
@@ -5,7 +5,7 @@ environment={% for key, value in environment_variables.items() %}{{ key }}="{{ v
 {% endif %}
 
 [program:frappe-bench-frappe-web]
-command=/home/frappe/frappe-bench/env/bin/gunicorn --bind 0.0.0.0:8000 --workers {{ gunicorn_workers }} --timeout {{ http_timeout }} --graceful-timeout 30 --max-requests 5000 --max-requests-jitter 1000 --worker-tmp-dir /dev/shm frappe.app:application --preload --statsd-host={{ statsd_host }} --statsd-prefix={{ name }} {% if gunicorn_threads_per_worker > 0 %} --worker-class=gthread --threads={{ gunicorn_threads_per_worker }}{% endif %} --reuse-port --worker-connections={{ (gunicorn_threads_per_worker + 1) * 2 }}
+command=/home/frappe/frappe-bench/env/bin/gunicorn --bind 0.0.0.0:8000 --workers {{ gunicorn_workers }} --timeout {{ http_timeout }} --graceful-timeout 30 --max-requests 5000 --max-requests-jitter 1000 --worker-tmp-dir /dev/shm frappe.app:application --preload --statsd-host={{ statsd_host }} --statsd-prefix={{ name }} {% if gunicorn_threads_per_worker > 0 %} --worker-class=gthread --threads={{ gunicorn_threads_per_worker }}{% endif %} --reuse-port --worker-connections={{ (gunicorn_threads_per_worker + 1) * 2 }} --keep-alive=15
 environment=FORWARDED_ALLOW_IPS="*"
 priority=4
 autostart=true


### PR DESCRIPTION
- Enable SO_REUSEPORT optimization for better load balancing
    - It also avoids waking up every worker for 1 request
- Lower max connections to # of threads. Why accept more than what is servicable
  here? Default is 1000! Changed it to 2x thread count. 2x is to accommodate keepalive connections and reduce TTFB during heavy workloads. Keeping it the same as the thread count will result in a serial chain from kernel to `gthread` threadpool manager to worker.
- Mirror `keepalive` timeout with nginx, both are now 15 seconds.