### PR TITLE
fix: Avoid auto restarting in single worker setups

### DIFF
--- a/agent/templates/bench/supervisor.conf
+++ b/agent/templates/bench/supervisor.conf
@@ -5,7 +5,7 @@ environment={% for key, value in environment_variables.items() %}{{ key }}="{{ v
 {% endif %}
 
 [program:frappe-bench-frappe-web]
-command=/home/frappe/frappe-bench/env/bin/gunicorn --bind 0.0.0.0:8000 --workers {{ gunicorn_workers }} --timeout {{ http_timeout }} --graceful-timeout 30 --max-requests 5000 --max-requests-jitter 1000 --worker-tmp-dir /dev/shm frappe.app:application --preload --statsd-host={{ statsd_host }} --statsd-prefix={{ name }} {% if gunicorn_threads_per_worker > 0 %} --worker-class=gthread --threads={{ gunicorn_threads_per_worker }}{% endif %} --reuse-port
+command=/home/frappe/frappe-bench/env/bin/gunicorn --bind 0.0.0.0:8000 --workers {{ gunicorn_workers }} --timeout {{ http_timeout }} --graceful-timeout 30 --worker-tmp-dir /dev/shm frappe.app:application --preload --statsd-host={{ statsd_host }} --statsd-prefix={{ name }} {% if gunicorn_threads_per_worker > 0 %} --worker-class=gthread --threads={{ gunicorn_threads_per_worker }}{% endif %} --reuse-port {% if gunicorn_workers > 1 %} --max-requests 5000 --max-requests-jitter 1000 {% endif %}
 environment=FORWARDED_ALLOW_IPS="*"
 priority=4
 autostart=true


### PR DESCRIPTION
This can cause a random smallish downtime when there's only 1 worker on bench. 