### PR TITLE
fix: limit connections a worker can accept at any time

### DIFF
--- a/agent/templates/bench/supervisor.conf
+++ b/agent/templates/bench/supervisor.conf
@@ -5,7 +5,7 @@ environment={% for key, value in environment_variables.items() %}{{ key }}="{{ v
 {% endif %}
 
 [program:frappe-bench-frappe-web]
-command=/home/frappe/frappe-bench/env/bin/gunicorn --bind 0.0.0.0:8000 --workers {{ gunicorn_workers }} --timeout {{ http_timeout }} --graceful-timeout 30 --worker-tmp-dir /dev/shm frappe.app:application --preload --statsd-host={{ statsd_host }} --statsd-prefix={{ name }} {% if gunicorn_threads_per_worker > 0 %} --worker-class=gthread --threads={{ gunicorn_threads_per_worker }}{% endif %} --reuse-port {% if gunicorn_workers > 1 %} --max-requests 5000 --max-requests-jitter 1000 {% endif %}
+command=/home/frappe/frappe-bench/env/bin/gunicorn --bind 0.0.0.0:8000 --workers {{ gunicorn_workers }} --timeout {{ http_timeout }} --graceful-timeout 30 --worker-tmp-dir /dev/shm frappe.app:application --preload --statsd-host={{ statsd_host }} --statsd-prefix={{ name }} {% if gunicorn_threads_per_worker > 0 %} --worker-class=gthread --threads={{ gunicorn_threads_per_worker }}{% endif %} {% if gunicorn_workers > 1 %} --max-requests 5000 --max-requests-jitter 1000 {% endif %} --worker-connections={{ (gunicorn_threads_per_worker + 2) }} --keep-alive=0
 environment=FORWARDED_ALLOW_IPS="*"
 priority=4
 autostart=true


### PR DESCRIPTION
- gthread by default accepts up to 1000 connections
- it can only serve `nthreads` requests at any time i.e. 2-6 in our deployments.
- So when worker dies it might have accepted 10s of requests which all get cancelled resulting in `502` error. 

Fix:
- Don't keep connections alive
- Limit accepted connections to `n+1` where `n` is number of threads. `n+1` avoids serial chain of `accept` -> `threadpool` and ensures better threadpool utilization. 


Note: diff says +2 because there's an off by one error in gunicorn logic, that doesn't matter much, we just need to avoid accepting huge number of requests +1 or +2 are both fine)


Things I verified:
- Throughput is not affected / only marginally affected for silly things like `ping` i.e. threadpool utilization is just fine.
- max futures never exceed `n+1`