### PR TITLE
feat: Implement Failover Support for Physical Restore

### DIFF
--- a/agent/database_physical_restore.py
+++ b/agent/database_physical_restore.py
@@ -327,7 +327,8 @@ class DatabasePhysicalRestore(DatabaseServer):
                 continue
 
             """
-            `frappe` user will not have perm to change group to mysql, so dont try to preserve it `frappe` uses
+            `frappe` user will not have perm to change group to mysql,
+            so dont try to preserve it `frappe` user
             """
             subprocess.run(
                 [

--- a/agent/database_physical_restore.py
+++ b/agent/database_physical_restore.py
@@ -326,9 +326,16 @@ class DatabasePhysicalRestore(DatabaseServer):
             if engine == "myisam" and not (file.endswith(".MYI") or file.endswith(".MYD")):
                 continue
 
-            shutil.copyfile(
-                os.path.join(self.backup_db_directory, file),
-                os.path.join(self.target_db_directory, file),
+            """
+            `frappe` user will not have perm to change group to mysql, so dont try to preserve it `frappe` uses
+            """
+            subprocess.run(
+                [
+                    "cp",
+                    "--no-preserve=all",
+                    os.path.join(self.backup_db_directory, file),
+                    os.path.join(self.target_db_directory, file),
+                ]
             )
 
     def _get_target_db(self) -> peewee.MySQLDatabase:

--- a/agent/web.py
+++ b/agent/web.py
@@ -1089,6 +1089,8 @@ def physical_restore_database():
         backup_db_base_directory=data.get("backup_db_base_directory", ""),
         restore_specific_tables=data.get("restore_specific_tables", False),
         tables_to_restore=data.get("tables_to_restore", []),
+        docker_image=data.get("docker_image"),
+        attempt_failover=data.get("attempt_failover", False),
     ).create_restore_job()
     return {"job": job}
 


### PR DESCRIPTION
If normal physical restoration failed for any reason,
We will spin up a new mariadb container with the backup volume mounted.

Then, we will try to dump and import the logical backup in live database.

**Flow -**

![image](https://github.com/user-attachments/assets/af5e0250-2dd3-4468-b991-9cec7de0c656)
