### PR TITLE
fix(physical-restore): InnoDB FTS Index Repair

### DIFF
--- a/agent/database_physical_restore.py
+++ b/agent/database_physical_restore.py
@@ -448,7 +448,7 @@ class DatabasePhysicalRestore(DatabaseServer):
         for index_name, columns in fts_indexes.items():
             run_sql_query(
                 self._get_target_db(raise_error_on_connection_closed=False),
-                "ALTER TABLE `{table}` DROP INDEX `{index_name}`;",
+                f"ALTER TABLE `{table}` DROP INDEX `{index_name}`;",
                 retries_on_lost_connection=3,
             )
             run_sql_query(
@@ -472,7 +472,7 @@ class DatabasePhysicalRestore(DatabaseServer):
         WHERE
             s.INDEX_TYPE = 'FULLTEXT'
             AND t.TABLE_SCHEMA = '{self.target_db}'
-            AND t.ENGINE = 'InnoDB'
+            AND t.ENGINE = 'InnoDB';
         """,
             retries_on_lost_connection=3,
         )
@@ -487,8 +487,8 @@ class DatabasePhysicalRestore(DatabaseServer):
         FROM
             information_schema.statistics
         WHERE
-            TABLE_SCHEMA = `{self.target_db}`
-            AND TABLE_NAME = `{table}`
+            TABLE_SCHEMA = '{self.target_db}'
+            AND TABLE_NAME = '{table}'
             AND INDEX_TYPE = 'FULLTEXT'
         GROUP BY
             INDEX_NAME;

--- a/agent/database_physical_restore.py
+++ b/agent/database_physical_restore.py
@@ -295,9 +295,9 @@ class DatabasePhysicalRestore(DatabaseServer):
         FLUSH TABLES ... FOR EXPORT does not support FULLTEXT indexes.
         https://dev.mysql.com/doc/refman/8.4/en/innodb-table-import.html#:~:text=in%20the%20operation.-,Limitations,-The%20Transportable%20Tablespaces
 
-        Need to drop + add all fulltext indexes of InnoDB tables.
-        Caution: OPTIMIZE TABLE does not work in case of fulltext index corruption. Only normal rebuild occur.
-        https://mariadb.com/kb/en/optimize-table/#updating-an-innodb-fulltext-index
+        Need to drop all fulltext indexes of InnoDB tables.
+        Then, optimize table to fix existing corruptions and rebuild table (if needed).
+        Then, recreate the fulltext indexes.
         """
 
         for table in innodb_tables_with_fts:


### PR DESCRIPTION
_Whatever MariaDB docs tell, doesn't work as it is for physical restore_

**InnoDB FullText Index Repair -**
- Drop the FTS indexes from table first
- `OPTIMIZE TABLE` for that specific table to fix corruptions. 
  If we don't do it, there will be almost no noticable issues. But, on fulltext index creation database will crash.

	```
	2025-03-10 09:37:32 0x7ff50c221700  InnoDB: Assertion failure in file /home/buildbot/buildbot/build/mariadb-10.6.21/storage/innobase/pars/pars0pars.cc line 771
	InnoDB: Failing assertion: sym_node->table != NULL
	250310  9:37:32 [ERROR] /usr/sbin/mariadbd got signal 6 ;
	Query (0x7ff3c4010c30): ALTER TABLE `tabHD Ticket` ADD FULLTEXT INDEX `hd_ticket_content`
	```
- Create the FTS indexes again.