### PR TITLE
feat: Snapshots to facilitate stuck process investigation

### DIFF
--- a/agent/bench.py
+++ b/agent/bench.py
@@ -333,16 +333,17 @@ class Bench(Base):
 
     def take_snapshot(self, pid_info: list[tuple[str, str]]):
         snapshots = []
+        pyspy_bin = os.path.join(self.server.directory, "env/bin/py-spy")
         for _name, pid in pid_info:
             try:
                 snapshots.append(
-                    json.loads(self.execute(f"sudo /home/frappe/agent/env/bin/py-spy dump --pid {pid} --json")["output"])
+                    json.loads(self.execute(f"sudo {pyspy_bin} dump --pid {pid} --json")["output"])
                 )
-            except AgentException:
+            except Exception:
+                # Process is mostly not running
                 continue
 
         return snapshots
-
 
     def status(self):
         status = {

--- a/agent/bench.py
+++ b/agent/bench.py
@@ -329,7 +329,7 @@ class Bench(Base):
 
     def get_worker_pids(self):
         """Get all the processes running gunicorn for now"""
-        return self._parse_pids(self.execute("ps aux | grep gunicorn")["output"])
+        return self._parse_pids(self.execute(f"docker top {self.name} | grep gunicorn")["output"])
 
     def take_snapshot(self, pid_info: list[tuple[str, str]]):
         snapshots = {}

--- a/agent/bench.py
+++ b/agent/bench.py
@@ -332,16 +332,16 @@ class Bench(Base):
         return self._parse_pids(self.execute("ps aux | grep gunicorn")["output"])
 
     def take_snapshot(self, pid_info: list[tuple[str, str]]):
-        snapshots = []
+        snapshots = {}
         pyspy_bin = os.path.join(self.server.directory, "env/bin/py-spy")
-        for _name, pid in pid_info:
+
+        for name, pid in pid_info:
             try:
-                snapshots.append(
-                    json.loads(self.execute(f"sudo {pyspy_bin} dump --pid {pid} --json")["output"])
+                snapshots[f"{name}:{pid}"] = json.loads(
+                    self.execute(f"sudo {pyspy_bin} dump --pid {pid} --json")["output"]
                 )
-            except Exception:
-                # Process is mostly not running
-                continue
+            except AgentException as e:
+                snapshots[f"{name}:{pid}"] = str(e)
 
         return snapshots
 

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -169,3 +169,7 @@ def get_mariadb_table_name_from_path(path: str) -> str:
     filename = os.path.splitext(filename)[0]
     # Decode the filename
     return decode_mariadb_filename(filename)
+
+
+def check_installed_pyspy(server_dir: str) -> bool:
+    return os.path.exists(os.path.join(server_dir, "env/bin/py-spy"))

--- a/agent/web.py
+++ b/agent/web.py
@@ -169,9 +169,7 @@ def get_snapshots(bench_name: str):
         return {"message": f"No such bench {bench_name}"}, 400
 
     pids = bench.get_worker_pids()
-    snapshots = bench.take_snapshot(pids)
-
-    return {"snapshots": snapshots}
+    return bench.take_snapshot(pids)
 
 
 @application.route("/ping_job", methods=["POST"])

--- a/agent/web.py
+++ b/agent/web.py
@@ -33,6 +33,7 @@ from agent.proxysql import ProxySQL
 from agent.security import Security
 from agent.server import Server
 from agent.ssh import SSHProxy
+from agent.utils import check_installed_pyspy
 
 if TYPE_CHECKING:
     from datetime import datetime, timedelta
@@ -161,12 +162,16 @@ def ping():
     return {"message": "pong"}
 
 
-@application.route("/snapshots/<string:bench_name>")
+@application.route("/snapshot/<string:bench_name>")
 def get_snapshots(bench_name: str):
-    bench = Server().benches.get(bench_name)
+    server = Server()
+    bench = server.benches.get(bench_name)
 
     if not bench:
         return {"message": f"No such bench {bench_name}"}, 400
+
+    if not check_installed_pyspy(server.directory):
+        return {"message": "PySpy is not installed on this server"}, 400
 
     pids = bench.get_worker_pids()
     return bench.take_snapshot(pids)

--- a/agent/web.py
+++ b/agent/web.py
@@ -161,6 +161,13 @@ def ping():
     return {"message": "pong"}
 
 
+@application.route("/snapshots/<string:bench_name>")
+def get_snapshots(bench_name: str):
+    bench = Server().benches.get(bench_name)
+    pids = bench.get_worker_pids()
+    snapshots = bench.take_snapshot(pids)
+    return {"snapshots": snapshots}
+
 @application.route("/ping_job", methods=["POST"])
 def ping_job():
     return {

--- a/agent/web.py
+++ b/agent/web.py
@@ -164,9 +164,15 @@ def ping():
 @application.route("/snapshots/<string:bench_name>")
 def get_snapshots(bench_name: str):
     bench = Server().benches.get(bench_name)
+
+    if not bench:
+        return {"message": f"No such bench {bench_name}"}, 400
+
     pids = bench.get_worker_pids()
     snapshots = bench.take_snapshot(pids)
+
     return {"snapshots": snapshots}
+
 
 @application.route("/ping_job", methods=["POST"])
 def ping_job():

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ docker==6.1.2
 filelock==3.13.1
 sentry-sdk[flask, rq]==2.1.1
 sql_metadata==2.15.0
+py-spy==0.4.0


### PR DESCRIPTION
Addresses [this](https://github.com/frappe/press/issues/2450)

REQUIRES
- frappe ALL = (root) NOPASSWD: /home/frappe/agent/env/bin/py-spy
in /etc/sudoers.d/frappe on all agent servers.


