### PR TITLE
fix: backwards support for missing press url

### DIFF
--- a/agent/server.py
+++ b/agent/server.py
@@ -37,7 +37,7 @@ class Server(Base):
 
     @property
     def press_url(self):
-        return self.config["press_url"]
+        return self.config.get("press_url", "https://frappecloud.com")
 
     def docker_login(self, registry):
         url = registry["url"]


### PR DESCRIPTION
* Old agents don't have press url in their config.