### PR TITLE
fix: Ensure `Wait for Enqueued Jobs` step does not fail silently

### DIFF
--- a/agent/site.py
+++ b/agent/site.py
@@ -466,7 +466,7 @@ class Site(Base):
 
     @step("Wait for Enqueued Jobs")
     def wait_till_ready(self):
-        WAIT_TIMEOUT = 120
+        WAIT_TIMEOUT = 600
         data = {"tries": []}
         start = time.time()
         while (time.time() - start) < WAIT_TIMEOUT:

--- a/agent/site.py
+++ b/agent/site.py
@@ -481,7 +481,7 @@ class Site(Base):
                 time.sleep(1)
 
         if not is_ready:
-            raise Exception("Timeout waiting for site to be ready")
+            raise Exception("Timed out while waiting for the site to become ready for migration")
 
         return data
 

--- a/agent/site.py
+++ b/agent/site.py
@@ -481,7 +481,10 @@ class Site(Base):
                 time.sleep(1)
 
         if not is_ready:
-            raise Exception("Timed out while waiting for the site to become ready for migration")
+            raise Exception(
+                f"Site not ready for migration after {WAIT_TIMEOUT}s."
+                f" Site might have lot of jobs in queue. Try again later."
+            )
 
         return data
 

--- a/agent/site.py
+++ b/agent/site.py
@@ -469,14 +469,20 @@ class Site(Base):
         WAIT_TIMEOUT = 600
         data = {"tries": []}
         start = time.time()
+        is_ready = False
         while (time.time() - start) < WAIT_TIMEOUT:
             try:
                 output = self.bench_execute("ready-for-migration")
                 data["tries"].append(output)
+                is_ready = True
                 break
             except Exception as e:
                 data["tries"].append(e.data)
                 time.sleep(1)
+
+        if not is_ready:
+            raise Exception("Timeout waiting for site to be ready")
+
         return data
 
     @step("Clear Backup Directory")


### PR DESCRIPTION
Fixes https://github.com/frappe/agent/issues/187

- Increase timeout to 5 minutes from 2 minutes.
- If still the jobs in site doesn't finish/stop within that time , just abort the operation