### PR TITLE
fix: Ensure atomic writes while writing config files

### DIFF
--- a/agent/app.py
+++ b/agent/app.py
@@ -7,6 +7,8 @@ from agent.base import Base
 
 class App(Base):
     def __init__(self, name, bench):
+        super.__init__()
+
         self.name = name
         self.directory = os.path.join(bench.directory, "apps", name)
         if not os.path.isdir(self.directory):

--- a/agent/base.py
+++ b/agent/base.py
@@ -280,8 +280,3 @@ class Base:
         if self._config_file_lock:
             with suppress(Exception):
                 self._config_file_lock.release()
-
-
-class AgentException(Exception):
-    def __init__(self, data):
-        self.data = data

--- a/agent/bench.py
+++ b/agent/bench.py
@@ -42,6 +42,8 @@ if TYPE_CHECKING:
 
 class Bench(Base):
     def __init__(self, name: str, server: Server, mounts=None):
+        super().__init__()
+
         self.name = name
         self.server = server
         self.directory = os.path.join(self.server.benches_directory, name)

--- a/agent/bench.py
+++ b/agent/bench.py
@@ -571,9 +571,9 @@ class Bench(Base):
         bench_config: dict | None = None,
     ):
         if common_site_config:
-            new_common_site_config = self.config
+            new_common_site_config = self.get_config(for_update=True)
             new_common_site_config.update(common_site_config)
-            self.setconfig(new_common_site_config)
+            self.set_config(new_common_site_config)
 
         if bench_config:
             new_bench_config = self.bench_config
@@ -847,13 +847,22 @@ class Bench(Base):
         }
 
     @property
-    def bench_config(self):
+    def bench_config(self) -> dict:
         with open(self.bench_config_file, "r") as f:
             return json.load(f)
 
     def set_bench_config(self, value, indent=1):
-        with open(self.bench_config_file, "w") as f:
-            json.dump(value, f, indent=indent, sort_keys=True)
+        """
+        To avoid partial writes, we need to first write the config to a temporary file,
+        then rename it to the original file.
+        """
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as temp_file:
+            json.dump(value, temp_file, indent=indent, sort_keys=True)
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+            temp_file.close()
+
+        os.rename(temp_file.name, self.config_file)
 
     @job("Patch App")
     def patch_app(

--- a/agent/cli.py
+++ b/agent/cli.py
@@ -124,10 +124,10 @@ def nginx():
 def proxy(domain=None, press_url=None):
     proxy = Proxy()
     if domain:
-        config = proxy.config
+        config = proxy.get_config(for_update=True)
         config["domain"] = domain
         config["press_url"] = press_url
-        proxy.setconfig(config, indent=4)
+        proxy.set_config(config, indent=4)
     proxy.setup_proxy()
 
 
@@ -136,10 +136,10 @@ def proxy(domain=None, press_url=None):
 def standalone(domain=None):
     server = Server()
     if domain:
-        config = server.config
+        config = server.get_config(for_update=True)
         config["domain"] = domain
         config["standalone"] = True
-        server.setconfig(config, indent=4)
+        server.set_config(config, indent=4)
 
 
 @setup.command()

--- a/agent/proxy.py
+++ b/agent/proxy.py
@@ -299,16 +299,17 @@ class Proxy(Server):
 
     def _generate_proxy_config(self):
         proxy_config_file = os.path.join(self.nginx_directory, "proxy.conf")
+        config = self.get_config()
         self._render_template(
             "proxy/nginx.conf.jinja2",
             {
                 "hosts": self.hosts,
                 "upstreams": self.upstreams,
-                "domain": self.config["domain"],
+                "domain": config["domain"],
                 "wildcards": self.wildcards,
-                "nginx_directory": self.config["nginx_directory"],
+                "nginx_directory": config["nginx_directory"],
                 "error_pages_directory": self.error_pages_directory,
-                "tls_protocols": self.config.get("tls_protocols"),
+                "tls_protocols": config.get("tls_protocols"),
             },
             proxy_config_file,
         )

--- a/agent/server.py
+++ b/agent/server.py
@@ -23,6 +23,8 @@ from agent.site import Site
 
 class Server(Base):
     def __init__(self, directory=None):
+        super().__init__()
+
         self.directory = directory or os.getcwd()
         self.config_file = os.path.join(self.directory, "config.json")
         self.name = self.config["name"]

--- a/agent/server.py
+++ b/agent/server.py
@@ -414,9 +414,9 @@ class Server(Base):
         self.update_config({"proxysql_admin_password": password})
 
     def update_config(self, value):
-        config = self.config
+        config = self.get_config(for_update=True)
         config.update(value)
-        self.setconfig(config, indent=4)
+        self.set_config(config, indent=4)
 
     def setup_registry(self):
         self.update_config({"registry": True})

--- a/agent/site.py
+++ b/agent/site.py
@@ -234,14 +234,14 @@ class Site(Base):
             remove (list, optional): Keys sent in the form of a list will be
                 popped from the existing site config. Defaults to None.
         """
-        new_config = self.config
+        new_config = self.get_config(for_update=True)
         new_config.update(value)
 
         if remove:
             for key in remove:
                 new_config.pop(key, None)
 
-        self.setconfig(new_config)
+        self.set_config(new_config)
 
     @job("Add Domain", priority="high")
     def add_domain(self, domain):

--- a/agent/site.py
+++ b/agent/site.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
 
 class Site(Base):
     def __init__(self, name: str, bench: Bench):
+        super().__init__()
+
         self.name = name
         self.bench = bench
         self.directory = os.path.join(self.bench.sites_directory, name)


### PR DESCRIPTION
Fixes https://github.com/frappe/press/issues/2617

Ensure two things -
- Atomic writes, so that if someway 2 writers start writing the file, the file doesn't corrupt. At max, we will lose one copy of file. [Need to write content to some tmp file and then do `os.rename`]
- Don't allow multiple writes or dirty reads, in `update_config` or `set_config` functions.