### PR TITLE
perf(poll): Add index to agent_job_id field

### DIFF
--- a/agent/cli.py
+++ b/agent/cli.py
@@ -148,6 +148,7 @@ def database():
     from agent.job import agent_database as database
 
     database.create_tables([JobModel, StepModel, PatchLogModel])
+    database.execute_sql("CREATE INDEX IF NOT EXISTS idx_jobmodel_agent_job_id ON jobmodel (agent_job_id)")
 
 
 @setup.command()


### PR DESCRIPTION
Fixes https://github.com/frappe/agent/issues/196 (1 of 2 issues)

https://github.com/frappe/agent/blob/d637bdf564cd5c9b51bccbcacc73ca6577528e9b/agent/web.py#L1363-L1378

This endpoint is used to poll bulk jobs from server by press.

It doesn't use any indexed column to search, instead use `agent_job_id` , which is actually the `name/id` of `Agent Job` on press. 

---

Indexing can make it way too fast here.

The sqlite database is 29GB

**Before Indexing -**

![Image](https://github.com/user-attachments/assets/a2dd0cc0-83f7-4b95-bf6a-f99ef80ccb92)

😅 7.5s

**After Indexing -**

![Image](https://github.com/user-attachments/assets/1387f9a8-5b23-47f5-928f-b1f207e758b1)

<1ms

