### PR TITLE
Fix AttributeError: '_config_file_lock' in Proxy Class Initialization

### DIFF
--- a/agent/proxy.py
+++ b/agent/proxy.py
@@ -20,7 +20,6 @@ class Proxy(Server):
         self.config_file = os.path.join(self.directory, "config.json")
         self.name = self.config["name"]
         self.domain = self.config.get("domain")
-        
         self.nginx_directory = self.config["nginx_directory"]
         self.upstreams_directory = os.path.join(self.nginx_directory, "upstreams")
         self.hosts_directory = os.path.join(self.nginx_directory, "hosts")

--- a/agent/proxy.py
+++ b/agent/proxy.py
@@ -27,7 +27,6 @@ class Proxy(Server):
         
         self.nginx_defer_reload_file = os.path.join(self.nginx_directory, "nginx_reload")
         self.nginx_defer_reload_lock_file = os.path.join(self.nginx_directory, "nginx_reload.lock")
-        
         self.job = None
         self.step = None
 

--- a/agent/proxy.py
+++ b/agent/proxy.py
@@ -15,19 +15,20 @@ from agent.server import Server
 
 class Proxy(Server):
     def __init__(self, directory=None):
+        super().__init__(directory)
         self.directory = directory or os.getcwd()
         self.config_file = os.path.join(self.directory, "config.json")
         self.name = self.config["name"]
         self.domain = self.config.get("domain")
-
+        
         self.nginx_directory = self.config["nginx_directory"]
         self.upstreams_directory = os.path.join(self.nginx_directory, "upstreams")
         self.hosts_directory = os.path.join(self.nginx_directory, "hosts")
         self.error_pages_directory = os.path.join(self.directory, "repo", "agent", "pages")
-
+        
         self.nginx_defer_reload_file = os.path.join(self.nginx_directory, "nginx_reload")
         self.nginx_defer_reload_lock_file = os.path.join(self.nginx_directory, "nginx_reload.lock")
-
+        
         self.job = None
         self.step = None
 

--- a/agent/proxy.py
+++ b/agent/proxy.py
@@ -24,7 +24,6 @@ class Proxy(Server):
         self.upstreams_directory = os.path.join(self.nginx_directory, "upstreams")
         self.hosts_directory = os.path.join(self.nginx_directory, "hosts")
         self.error_pages_directory = os.path.join(self.directory, "repo", "agent", "pages")
-        
         self.nginx_defer_reload_file = os.path.join(self.nginx_directory, "nginx_reload")
         self.nginx_defer_reload_lock_file = os.path.join(self.nginx_directory, "nginx_reload.lock")
         self.job = None


### PR DESCRIPTION
Traceback (most recent call last):
  File "/home/frappe/agent/env/bin/agent", line 11, in <module>
    load_entry_point('agent', 'console_scripts', 'agent')()
  File "/home/frappe/agent/env/lib/python3.8/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/agent/env/lib/python3.8/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/frappe/agent/env/lib/python3.8/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/agent/env/lib/python3.8/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/agent/env/lib/python3.8/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/agent/env/lib/python3.8/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/frappe/agent/repo/agent/cli.py", line 127, in proxy
    config = proxy.get_config(for_update=True)
  File "/home/frappe/agent/repo/agent/base.py", line 203, in get_config
    if not self._config_file_lock:
AttributeError: 'Proxy' object has no attribute '_config_file_lock'
Exception ignored in: <function Base.__del__ at 0x7fa7080cd550>
Traceback (most recent call last):
  File "/home/frappe/agent/repo/agent/base.py", line 280, in __del__
    if self._config_file_lock:
AttributeError: 'Proxy' object has no attribute '_config_file_lock'