### PR TITLE
revamp: Better update and rollback support

### DIFF
--- a/agent/cli.py
+++ b/agent/cli.py
@@ -29,8 +29,17 @@ def setup():
 
 
 @cli.command()
-def update():
-    Server().update_agent_cli()
+@click.option("--restart-web-workers", default=True)
+@click.option("--restart-rq-workers", default=True)
+@click.option("--restart-redis", default=True)
+@click.option("--commit")
+def update(restart_web_workers, restart_rq_workers, restart_redis, commit: str):
+    Server().update_agent_cli(
+        restart_redis=restart_redis,
+        restart_rq_workers=restart_rq_workers,
+        restart_web_workers=restart_web_workers,
+        commit=commit,
+    )
 
 
 @cli.command()

--- a/agent/cli.py
+++ b/agent/cli.py
@@ -32,13 +32,13 @@ def setup():
 @click.option("--restart-web-workers", default=True)
 @click.option("--restart-rq-workers", default=True)
 @click.option("--restart-redis", default=True)
-@click.option("--commit")
-def update(restart_web_workers, restart_rq_workers, restart_redis, commit: str):
+@click.option("--skip-repo-setup", default=False)
+def update(restart_web_workers, restart_rq_workers, restart_redis, skip_repo_setup):
     Server().update_agent_cli(
         restart_redis=restart_redis,
         restart_rq_workers=restart_rq_workers,
         restart_web_workers=restart_web_workers,
-        commit=commit,
+        skip_repo_setup=skip_repo_setup
     )
 
 

--- a/agent/cli.py
+++ b/agent/cli.py
@@ -38,7 +38,7 @@ def update(restart_web_workers, restart_rq_workers, restart_redis, skip_repo_set
         restart_redis=restart_redis,
         restart_rq_workers=restart_rq_workers,
         restart_web_workers=restart_web_workers,
-        skip_repo_setup=skip_repo_setup
+        skip_repo_setup=skip_repo_setup,
     )
 
 

--- a/agent/server.py
+++ b/agent/server.py
@@ -19,7 +19,7 @@ from agent.exceptions import BenchNotExistsException
 from agent.job import Job, Step, job, step
 from agent.patch_handler import run_patches
 from agent.site import Site
-from agent.utils import get_supervisor_status
+from agent.utils import get_supervisor_processes_status
 
 
 class Server(Base):
@@ -395,8 +395,10 @@ class Server(Base):
             shutil.move(destination, archived_site_path)
         shutil.move(site.directory, target.sites_directory)
 
-    def execute(self, command, directory=None, skip_output_log=False):
-        return super().execute(command, directory=directory, skip_output_log=skip_output_log)
+    def execute(self, command, directory=None, skip_output_log=False, non_zero_throw=True):
+        return super().execute(
+            command, directory=directory, skip_output_log=skip_output_log, non_zero_throw=non_zero_throw
+        )
 
     @job("Reload NGINX")
     def restart_nginx(self):
@@ -526,25 +528,25 @@ class Server(Base):
             self.execute("git merge --ff-only upstream/master", directory=directory)
             self.execute("./env/bin/pip install -e repo", directory=self.directory)
 
-        supervisor_status = get_supervisor_status()
+        supervisor_status = get_supervisor_processes_status()
 
         # Stop web service
         if restart_web_workers and supervisor_status.get("web") == "RUNNING":
-            self.execute("sudo supervisorctl stop agent:web")
+            self.execute("sudo supervisorctl stop agent:web", non_zero_throw=False)
 
         # Stop required services
         if restart_rq_workers:
             for worker_id in supervisor_status.get("worker", {}):
-                self.execute(f"sudo supervisorctl stop agent:worker-{worker_id}")
+                self.execute(f"sudo supervisorctl stop agent:worker-{worker_id}", non_zero_throw=False)
 
         # Stop redis
         if restart_redis and supervisor_status.get("redis") == "RUNNING":
-            self.execute("sudo supervisorctl stop agent:redis")
+            self.execute("sudo supervisorctl stop agent:redis", non_zero_throw=False)
 
         self.setup_supervisor()
 
         # Start back services in same order
-        supervisor_status = get_supervisor_status()
+        supervisor_status = get_supervisor_processes_status()
         if restart_redis or supervisor_status.get("redis") != "RUNNING":
             self.execute("sudo supervisorctl start agent:redis")
 
@@ -566,6 +568,7 @@ class Server(Base):
             "upstream": self.execute("git remote get-url upstream", directory=directory)["output"],
             "show": self.execute("git show", directory=directory)["output"],
             "python": platform.python_version(),
+            "services": get_supervisor_processes_status(),
         }
 
     def status(self, mariadb_root_password):

--- a/agent/server.py
+++ b/agent/server.py
@@ -516,18 +516,15 @@ class Server(Base):
         run_patches()
 
     def update_agent_cli(  # noqa: C901
-        self, commit: str, restart_redis=True, restart_rq_workers=True, restart_web_workers=True
+        self, restart_redis=True, restart_rq_workers=True, restart_web_workers=True, skip_repo_setup=False
     ):
         directory = os.path.join(self.directory, "repo")
-        self.execute("git reset --hard", directory=directory)
-        self.execute("git clean -fd", directory=directory)
-        self.execute("git fetch upstream", directory=directory)
-        self.execute("git merge --ff-only upstream/master", directory=directory)
-
-        if commit:
-            self.execute(f"git checkout {commit}", directory=directory)
-
-        self.execute("./env/bin/pip install -e repo", directory=self.directory)
+        if skip_repo_setup:
+            self.execute("git reset --hard", directory=directory)
+            self.execute("git clean -fd", directory=directory)
+            self.execute("git fetch upstream", directory=directory)
+            self.execute("git merge --ff-only upstream/master", directory=directory)
+            self.execute("./env/bin/pip install -e repo", directory=self.directory)
 
         supervisor_status = get_supervisor_status()
 

--- a/agent/templates/agent/supervisor.conf.jinja2
+++ b/agent/templates/agent/supervisor.conf.jinja2
@@ -18,7 +18,7 @@ user={{ user }}
 directory={{ directory }}
 
 [program:worker]
-command=bash -c "{{ directory }}/repo/wait-for-it.sh redis://127.0.0.1:{{ redis_port }} && {{ directory }}/env/bin/rq worker {% if sentry_dsn %}--sentry-dsn '{{ sentry_dsn }}'{% endif %} --url redis://127.0.0.1:{{ redis_port }} high default low"
+command=bash -c "{{ directory }}/repo/wait-for-it.sh redis://127.0.0.1:{{ redis_port }} && exec {{ directory }}/env/bin/rq worker {% if sentry_dsn %}--sentry-dsn '{{ sentry_dsn }}'{% endif %} --url redis://127.0.0.1:{{ redis_port }} high default low"
 environment=PYTHONUNBUFFERED=1
 autostart=true
 autorestart=true

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -183,9 +183,9 @@ def check_installed_pyspy(server_dir: str) -> bool:
     return os.path.exists(os.path.join(server_dir, "env/bin/py-spy"))
 
 
-def get_supervisor_status() -> dict[str, str | dict[str, str]]:
+def get_supervisor_processes_status() -> dict[str, str | dict[str, str]]:
     try:
-        output = subprocess.check_output("sudo supervisorctl status", shell=True)
+        output = subprocess.check_output("sudo supervisorctl status all", shell=True)
         lines = output.decode("utf-8").strip().split("\n")
 
         flat_status = {}

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import hashlib
 import os
 import re
+import subprocess
+from collections import defaultdict
 from datetime import datetime, timedelta
 from math import ceil
 from typing import TYPE_CHECKING
@@ -179,3 +181,40 @@ def get_mariadb_table_name_from_path(path: str) -> str:
 
 def check_installed_pyspy(server_dir: str) -> bool:
     return os.path.exists(os.path.join(server_dir, "env/bin/py-spy"))
+
+
+def get_supervisor_status() -> dict[str, str | dict[str, str]]:
+    try:
+        output = subprocess.check_output("sudo supervisorctl status", shell=True)
+        lines = output.decode("utf-8").strip().split("\n")
+
+        flat_status = {}
+
+        for line in lines:
+            parts = line.split()
+            if len(parts) < 2:
+                continue
+            name = parts[0].strip()
+            state = parts[1].strip()
+
+            if not name.startswith("agent:"):
+                continue
+
+            # Strip `agent:` prefix if present
+            name = name[len("agent:") :]
+
+            flat_status[name] = state
+
+        nested_status = defaultdict(dict)
+
+        for name, state in flat_status.items():
+            # Match pattern like worker-1, worker-2, etc.
+            if "-" in name:
+                group, sub = name.split("-", 1)
+                nested_status[group][sub] = state
+            else:
+                nested_status[name] = state
+
+        return dict(nested_status)
+    except Exception:
+        return {}


### PR DESCRIPTION
Related https://github.com/frappe/press/issues/2660

**Tasks -**

- [x]  Allow to restart only specific services
    - Web worker
    - BG Worker
    - Redis
- [x] Graceful restart workers ( Don't force kill workers, Pause processing of queued jobs, Wait for running jobs)
- [x] Version API should return supervisor processes status

---

**agent update**

```python
@click.option("--restart-web-workers", default=True)
@click.option("--restart-rq-workers", default=True)
@click.option("--restart-redis", default=True)
@click.option("--skip-repo-setup", default=False)
```