### PR TITLE
perf: Rewrite redis aof weekly

### DIFF
--- a/agent/cli.py
+++ b/agent/cli.py
@@ -206,6 +206,27 @@ def usage():
 
 
 @setup.command()
+def rewrite_redis_aof_weekly():
+    from crontab import CronTab
+
+    script_directory = os.path.dirname(__file__)
+    agent_directory = os.path.dirname(os.path.dirname(script_directory))
+    logs_directory = os.path.join(agent_directory, "logs")
+    script = os.path.join(script_directory, "rewrite_redis_aof.py")
+    stdout = os.path.join(logs_directory, "rewrite_redis_aof.log")
+    stderr = os.path.join(logs_directory, "rewrite_redis_aof.error.log")
+
+    cron = CronTab(user=True)
+    command = f"cd {agent_directory} && {sys.executable} {script} 1>> {stdout} 2>> {stderr}"
+
+    if command not in str(cron):
+        job = cron.new(command=command)
+        job.every(7).weeks()
+        job.hour.on(2)
+        cron.write()
+
+
+@setup.command()
 def nginx_defer_reload():
     from crontab import CronTab
 

--- a/agent/rewrite_redis_aof.py
+++ b/agent/rewrite_redis_aof.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import sys
+
+from agent.job import connection as redis_connection
+
+if __name__ == "__main__":
+    try:
+        conn = redis_connection()
+        if not conn.ping():
+            raise Exception("Redis is not running")
+
+        conn.bgrewriteaof()
+    except Exception as e:
+        print(f"Failed to rewrite redis AOF : {e!s}", file=sys.stderr)


### PR DESCRIPTION
**Problem -**

Redis provides presistency by storing db in `rdb` and `aof` format.

- rdb file is just like a state of db, but it's not time consistent
- aof file on the other end holds all the write query running against redis. It's time consistent.

For obsvious reason, aof file will be huge. Redis provide support to rewrite aof file.

We use aof mainly.
In some cases, `aof` files are `1GB` to `~250GB` size.
Where the `rdb` file is under 50MB mostly.

It impact agent's perf. But the main issue, it slow down redis startup and  after agent update, worker takes too long to up in wait for redis.

**Solution -**

Redis provides support to rewrite the aof file from in memory data - [bgrewriteaof](https://redis.io/docs/latest/commands/bgrewriteaof/)

So, on agent weekly it will rewrite aof to squeeze the size.