### PR TITLE
chore(arm): Platform support in image builder

### DIFF
--- a/agent/builder.py
+++ b/agent/builder.py
@@ -38,6 +38,10 @@ class ImageBuilder(Base):
         self.image_repository = image_repository
         self.image_tag = image_tag
         self.registry = registry
+
+        if not platform.startswith("linux/"):
+            platform = f"linux/{platform}"
+
         self.platform = platform
 
         # Build context, params


### PR DESCRIPTION
Address inconsitancy between server platform (build server) and `buildx` platform syntax