### PR TITLE
fix(base): Handle windows style carriage returns

### DIFF
--- a/agent/base.py
+++ b/agent/base.py
@@ -125,6 +125,7 @@ class Base:
             if char == b"" and process.poll() is not None:
                 break
             if char == b"\r":
+                prev_char = char
                 continue  # Ignore carriage return; handled in next iteration
             if char == b"\n":
                 lines.append(line.decode(errors="replace"))


### PR DESCRIPTION
\r\n is used for docker output which is not being captured
![image](https://github.com/user-attachments/assets/cb2d014a-4be1-4e3b-8c31-b202c85b1402)

Now those output can be propagated also 
![image](https://github.com/user-attachments/assets/f1646556-5931-43bc-b153-2382596ab591)
