### PR TITLE
feat(registry): Check registry status before image push

### DIFF
--- a/agent/exceptions.py
+++ b/agent/exceptions.py
@@ -27,3 +27,8 @@ class InvalidSiteConfigException(AgentException):
     def __init__(self, data: dict, site=None):
         self.site = site
         super().__init__(data)
+
+
+class RegistryDownException(Exception):
+    def __init__(self, data):
+        self.data = data

--- a/agent/server.py
+++ b/agent/server.py
@@ -28,6 +28,7 @@ from agent.patch_handler import run_patches
 from agent.site import Site
 from agent.utils import get_supervisor_processes_status
 
+
 class Server(Base):
     def __init__(self, directory=None):
         super().__init__()


### PR DESCRIPTION
Checks registry health before and after a push, if container is being restarted or is down retry after 60 seconds, for a max of 3 retries.