### PR TITLE
fix(nginx): Set busy buffer size in agent config

### DIFF
--- a/agent/templates/agent/nginx.conf.jinja2
+++ b/agent/templates/agent/nginx.conf.jinja2
@@ -286,6 +286,7 @@ server {
 	location / {
 		proxy_buffer_size 32k;
 		proxy_buffers 8 16k;
+		proxy_busy_buffers_size 32k;
 		proxy_set_header X-Forwarded-For $remote_addr;
 		proxy_pass http://127.0.0.1:9000/;
 	}

--- a/agent/templates/proxy/nginx.conf.jinja2
+++ b/agent/templates/proxy/nginx.conf.jinja2
@@ -163,6 +163,7 @@ server {
 		proxy_buffering off;
 		proxy_buffer_size 128k;
 		proxy_buffers 100 128k;
+		proxy_busy_buffers_size 128k;
 
 		proxy_set_header Host $host;
 		proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
We have set a busy buffer size to 8k in server block so, now it's imporant to add busy_buffer_size
wherever we have configure buffer_size