### PR TITLE
fix(server): Always raise error when nginx reload fails

### DIFF
--- a/agent/server.py
+++ b/agent/server.py
@@ -945,9 +945,11 @@ class Server(Base):
             return self.execute("sudo systemctl reload nginx")
         except AgentException as e:
             try:
-                return self.execute("sudo nginx -t")
+                self.execute("sudo nginx -t")
             except AgentException as e2:
                 raise e2 from e
+            else:
+                raise e
 
     def _render_template(self, template, context, outfile, options=None):
         if options is None:


### PR DESCRIPTION
Nginx reload might fail even though nginx -t works?
