### PR TITLE
fix(agent-update): Regenerate core nginx config for proxy servers

### DIFF
--- a/agent/server.py
+++ b/agent/server.py
@@ -834,8 +834,14 @@ class Server(Base):
         if restart_redis or supervisor_status.get("redis") != "RUNNING":
             self.execute("sudo supervisorctl start agent:redis")
 
-        # Start NGINX Reload Manager if it's a proxy server
         if is_proxy_server:
+            from agent.proxy import Proxy
+
+            # Call proxy setup to re-generate configuration
+            proxy = Proxy()
+            proxy.setup_proxy()
+
+            # Start NGINX Reload Manager if it's a proxy server
             self.execute("sudo supervisorctl start agent:nginx_reload_manager")
 
         if restart_rq_workers:

--- a/agent/site.py
+++ b/agent/site.py
@@ -693,6 +693,7 @@ class Site(Base):
     @step("Rebuild global search")
     def rebuild_global_search_step(self):
         import json
+
         """Execute bench rebuild-global-search command."""
         result = self.bench_execute("rebuild-global-search")
 


### PR DESCRIPTION
In some cases, we can have conflicting updates with old version To mitigate that, we should do setup_proxy in case of any agent update on proxy server