### PR TITLE
refactor: Replace SoftFileLock with FileLock

### DIFF
--- a/agent/base.py
+++ b/agent/base.py
@@ -36,7 +36,7 @@ class Base:
         self.data: dict[str, str] = {}
 
         # internal
-        self._config_file_lock: filelock.SoftFileLock | None = None
+        self._config_file_lock: filelock.FileLock | None = None
 
     def __repr__(self):
         return f"{self.__class__.__name__}({self.name})"
@@ -206,7 +206,7 @@ class Base:
         """
         if for_update:
             if not self._config_file_lock:
-                self._config_file_lock = filelock.SoftFileLock(self.config_file + ".lock")
+                self._config_file_lock = filelock.FileLock(self.config_file + ".lock")
             self._config_file_lock.acquire()
 
         with open(self.config_file, "r") as f:

--- a/agent/nfs_handler.py
+++ b/agent/nfs_handler.py
@@ -27,7 +27,7 @@ class NFSHandler:
         os.makedirs(self.shared_directory, exist_ok=True)
         self.server.execute(f"chown -R frappe:frappe {self.shared_directory}")
 
-        lock = filelock.SoftFileLock(self.exports_file + ".lock")
+        lock = filelock.FileLock(self.exports_file + ".lock")
 
         with lock.acquire(timeout=10), open(self.exports_file, "a+") as f:
             f.write(f"{self.shared_directory} {secondary_server_private_ip}({self.options})\n")
@@ -40,7 +40,7 @@ class NFSHandler:
             f"{self.shared_directory} {secondary_server_private_ip}({self.options})",
         ]
         for line in remove_lines:
-            lock = filelock.SoftFileLock(self.exports_file + ".lock")
+            lock = filelock.FileLock(self.exports_file + ".lock")
             with lock.acquire(timeout=10):
                 self.server.execute(f"sed -i '\\|{line}|d' {self.exports_file}")
 


### PR DESCRIPTION
SoftFileLock works only based on the presence of lock file. So, for some reason the lock file doesn't get cleared, then it can cause deadlock issue.


https://py-filelock.readthedocs.io/en/latest/#filelock-vs-softfilelock