### PR TITLE
fix: Add site backup and s3 upload to site archival and app uninstall

### DIFF
--- a/agent/bench.py
+++ b/agent/bench.py
@@ -480,18 +480,15 @@ class Bench(Base):
         if os.path.exists(site_directory):
             if offsite:
                 site = Site(name, self)
-                try:
-                    backup_files = site.backup(with_files=True)
-                    uploaded_files = (
-                        site.upload_offsite_backup(
-                            backup_files, offsite, keep_files_locally_after_offsite_backup=False
-                        )
-                        if (backup_files)
-                        else {}
+                backup_files = site.backup(with_files=True)
+                uploaded_files = (
+                    site.upload_offsite_backup(
+                        backup_files, offsite, keep_files_locally_after_offsite_backup=False
                     )
-                    backups = {"backups": backup_files, "offsite": uploaded_files}
-                except Exception as e:
-                    raise e
+                    if (backup_files)
+                    else {}
+                )
+                backups = {"backups": backup_files, "offsite": uploaded_files}
 
             self.bench_archive_site(
                 name,

--- a/agent/site.py
+++ b/agent/site.py
@@ -273,18 +273,15 @@ class Site(Base):
     def uninstall_app_job(self, app, offsite=None):
         backups = None
         if offsite:
-            try:
-                backup_files = self.backup(with_files=True)
-                uploaded_files = (
-                    self.upload_offsite_backup(
-                        backup_files, offsite, keep_files_locally_after_offsite_backup=False
-                    )
-                    if (backup_files)
-                    else {}
+            backup_files = self.backup(with_files=True)
+            uploaded_files = (
+                self.upload_offsite_backup(
+                    backup_files, offsite, keep_files_locally_after_offsite_backup=False
                 )
-                backups = {"backups": backup_files, "offsite": uploaded_files}
-            except Exception as e:
-                raise e
+                if (backup_files)
+                else {}
+            )
+            backups = {"backups": backup_files, "offsite": uploaded_files}
         self.uninstall_app(app)
         return backups
 

--- a/agent/web.py
+++ b/agent/web.py
@@ -694,7 +694,7 @@ def install_app_site(bench, site):
 )
 @validate_bench_and_site
 def uninstall_app_site(bench, site, app):
-    data = request.json
+    data = request.json or {}
     job = Server().benches[bench].sites[site].uninstall_app_job(app, data.get("offsite", {}))
     return {"job": job}
 


### PR DESCRIPTION
- Modified uninstall_app_site and archive_site endpoints to accept and pass through offsite configuration
- Updated uninstall_app to use --no-backup flag to prevent automatic backup (backup is now handled separately when needed)