### PR TITLE
feat: add site-aware CORS headers to bench nginx config

### DIFF
--- a/agent/bench.py
+++ b/agent/bench.py
@@ -547,9 +547,7 @@ class Bench(Base):
             "nginx_directory": self.server.nginx_directory,
             "tls_protocols": self.server.config.get("tls_protocols"),
             "code_server": codeserver,
-            "cors_origins": _get_cors_origins(
-                sites, self.common_site_config.get("allow_cors")
-            ),
+            "cors_origins": _get_cors_origins(sites, self.common_site_config.get("allow_cors")),
         }
         nginx_config = os.path.join(self.directory, "nginx.conf")
 
@@ -1427,9 +1425,7 @@ def _normalize_cors_origins(origins: str | list[str] | None) -> list[str]:
     return [origin.strip() for origin in origins if origin and origin.strip()]
 
 
-def _get_cors_origins(
-    sites: list[Site], bench_cors: str | list[str] | None = None
-) -> list[tuple[str, str]]:
+def _get_cors_origins(sites: list[Site], bench_cors: str | list[str] | None = None) -> list[tuple[str, str]]:
     """Return nginx map entries for site-aware CORS responses.
 
     Exact origins are matched against ``$host:$http_origin`` and echoed back
@@ -1444,11 +1440,7 @@ def _get_cors_origins(
 
     for site in sites:
         site_cors = site.config.get("allow_cors")
-        origins = (
-            _normalize_cors_origins(site_cors)
-            if site_cors is not None
-            else default_origins
-        )
+        origins = _normalize_cors_origins(site_cors) if site_cors is not None else default_origins
         if not origins:
             continue
 

--- a/agent/bench.py
+++ b/agent/bench.py
@@ -547,6 +547,9 @@ class Bench(Base):
             "nginx_directory": self.server.nginx_directory,
             "tls_protocols": self.server.config.get("tls_protocols"),
             "code_server": codeserver,
+            "cors_origins": _get_cors_origins(
+                sites, self.common_site_config.get("allow_cors")
+            ),
         }
         nginx_config = os.path.join(self.directory, "nginx.conf")
 
@@ -1412,6 +1415,52 @@ def _get_domains(sites: list[Site]):
         for domain in site.config.get("domains", []):
             domains[domain] = site.name
     return domains
+
+
+def _normalize_cors_origins(origins: str | list[str] | None) -> list[str]:
+    if origins is None:
+        return []
+
+    if isinstance(origins, str):
+        origins = [origins]
+
+    return [origin.strip() for origin in origins if origin and origin.strip()]
+
+
+def _get_cors_origins(
+    sites: list[Site], bench_cors: str | list[str] | None = None
+) -> list[tuple[str, str]]:
+    """Return nginx map entries for site-aware CORS responses.
+
+    Exact origins are matched against ``$host:$http_origin`` and echoed back
+    as ``$http_origin``. Wildcards are matched per-host and return ``"*"``.
+
+    Site-level ``allow_cors`` overrides bench-level (``common_site_config``).
+    A site explicitly setting ``allow_cors`` to ``[]`` disables CORS even if
+    the bench default is set.
+    """
+    pairs: set[tuple[str, str]] = set()
+    default_origins = _normalize_cors_origins(bench_cors)
+
+    for site in sites:
+        site_cors = site.config.get("allow_cors")
+        origins = (
+            _normalize_cors_origins(site_cors)
+            if site_cors is not None
+            else default_origins
+        )
+        if not origins:
+            continue
+
+        hostnames = [site.name, *site.config.get("domains", [])]
+        for hostname in hostnames:
+            for origin in origins:
+                if origin == "*":
+                    pairs.add((rf"~^{re.escape(hostname)}:.*$", '"*"'))
+                else:
+                    pairs.add((f'"{hostname}:{origin}"', "$http_origin"))
+
+    return sorted(pairs)
 
 
 def _get_codeserver_config(bench_directory: str):

--- a/agent/templates/bench/nginx.conf.jinja2
+++ b/agent/templates/bench/nginx.conf.jinja2
@@ -16,6 +16,26 @@ map $host $site_name_{{ bench_name_slug }} {
 	default $host;
 }
 
+{% if cors_origins %}
+map "$host:$http_origin" $cors_origin_{{ bench_name_slug }} {
+	default "";
+	{% for matcher, origin in cors_origins -%}
+		{{ matcher }} {{ origin }};
+	{% endfor %}
+}
+
+map $cors_origin_{{ bench_name_slug }} $cors_methods_{{ bench_name_slug }} {
+	"" "";
+	default "GET, OPTIONS";
+}
+
+map $cors_origin_{{ bench_name_slug }} $cors_vary_{{ bench_name_slug }} {
+	"" "";
+	"*" "";
+	default "Origin";
+}
+{% endif %}
+
 # server blocks
 {% if sites -%}
 
@@ -58,6 +78,18 @@ server {
 	location /assets {
 		try_files $uri =404;
 		add_header Cache-Control "max-age=31536000, immutable";
+		{% if cors_origins %}
+		add_header Access-Control-Allow-Origin $cors_origin_{{ bench_name_slug }} always;
+		add_header Access-Control-Allow-Methods $cors_methods_{{ bench_name_slug }} always;
+		add_header Vary $cors_vary_{{ bench_name_slug }} always;
+		if ($request_method = OPTIONS) {
+			add_header Access-Control-Allow-Origin $cors_origin_{{ bench_name_slug }} always;
+			add_header Access-Control-Allow-Methods $cors_methods_{{ bench_name_slug }} always;
+			add_header Access-Control-Max-Age 86400 always;
+			add_header Vary $cors_vary_{{ bench_name_slug }} always;
+			return 204;
+		}
+		{% endif %}
 	}
 
 	location ~ ^/protected/(.*) {
@@ -82,14 +114,30 @@ server {
 		rewrite ^(.+)/index\.html$ https://$host$1 permanent;
 		rewrite ^(.+)\.html$ https://$host$1 permanent;
 
+		{% if cors_origins %}
+		add_header Access-Control-Allow-Origin $cors_origin_{{ bench_name_slug }} always;
+		add_header Access-Control-Allow-Methods $cors_methods_{{ bench_name_slug }} always;
+		add_header Vary $cors_vary_{{ bench_name_slug }} always;
+		{% endif %}
+
 		location ~* ^/files/.*.(htm|html|svg|xml) {
 			add_header Content-disposition "attachment";
 			add_header Cache-Control "max-age=3600,stale-while-revalidate=86400";
+			{% if cors_origins %}
+			add_header Access-Control-Allow-Origin $cors_origin_{{ bench_name_slug }} always;
+			add_header Access-Control-Allow-Methods $cors_methods_{{ bench_name_slug }} always;
+			add_header Vary $cors_vary_{{ bench_name_slug }} always;
+			{% endif %}
 			try_files /$site_name_{{ bench_name_slug }}/public/$uri @webserver;
 		}
 
 		location ~* ^/files/.*.(png|jpe?g|gif|css|js|mp3|wav|ogg|flac|avi|mov|mp4|m4v|mkv|webm) {
 			add_header Cache-Control "max-age=3600,stale-while-revalidate=86400";
+			{% if cors_origins %}
+			add_header Access-Control-Allow-Origin $cors_origin_{{ bench_name_slug }} always;
+			add_header Access-Control-Allow-Methods $cors_methods_{{ bench_name_slug }} always;
+			add_header Vary $cors_vary_{{ bench_name_slug }} always;
+			{% endif %}
 			try_files /$site_name_{{ bench_name_slug }}/public/$uri @webserver;
 		}
 
@@ -191,6 +239,18 @@ server {
 	location /assets {
 		try_files $uri =404;
 		add_header Cache-Control "max-age=31536000, immutable";
+		{% if cors_origins %}
+		add_header Access-Control-Allow-Origin $cors_origin_{{ bench_name_slug }} always;
+		add_header Access-Control-Allow-Methods $cors_methods_{{ bench_name_slug }} always;
+		add_header Vary $cors_vary_{{ bench_name_slug }} always;
+		if ($request_method = OPTIONS) {
+			add_header Access-Control-Allow-Origin $cors_origin_{{ bench_name_slug }} always;
+			add_header Access-Control-Allow-Methods $cors_methods_{{ bench_name_slug }} always;
+			add_header Access-Control-Max-Age 86400 always;
+			add_header Vary $cors_vary_{{ bench_name_slug }} always;
+			return 204;
+		}
+		{% endif %}
 	}
 
 	location ~ ^/protected/(.*) {
@@ -215,14 +275,30 @@ server {
 		rewrite ^(.+)/index\.html$ https://$host$1 permanent;
 		rewrite ^(.+)\.html$ https://$host$1 permanent;
 
+		{% if cors_origins %}
+		add_header Access-Control-Allow-Origin $cors_origin_{{ bench_name_slug }} always;
+		add_header Access-Control-Allow-Methods $cors_methods_{{ bench_name_slug }} always;
+		add_header Vary $cors_vary_{{ bench_name_slug }} always;
+		{% endif %}
+
 		location ~* ^/files/.*.(htm|html|svg|xml) {
 			add_header Content-disposition "attachment";
 			add_header Cache-Control "max-age=3600,stale-while-revalidate=86400";
+			{% if cors_origins %}
+			add_header Access-Control-Allow-Origin $cors_origin_{{ bench_name_slug }} always;
+			add_header Access-Control-Allow-Methods $cors_methods_{{ bench_name_slug }} always;
+			add_header Vary $cors_vary_{{ bench_name_slug }} always;
+			{% endif %}
 			try_files /$site_name_{{ bench_name_slug }}/public/$uri @webserver;
 		}
 
 		location ~* ^/files/.*.(png|jpe?g|gif|css|js|mp3|wav|ogg|flac|avi|mov|mp4|m4v|mkv|webm) {
 			add_header Cache-Control "max-age=3600,stale-while-revalidate=86400";
+			{% if cors_origins %}
+			add_header Access-Control-Allow-Origin $cors_origin_{{ bench_name_slug }} always;
+			add_header Access-Control-Allow-Methods $cors_methods_{{ bench_name_slug }} always;
+			add_header Vary $cors_vary_{{ bench_name_slug }} always;
+			{% endif %}
 			try_files /$site_name_{{ bench_name_slug }}/public/$uri @webserver;
 		}
 

--- a/agent/tests/test_site.py
+++ b/agent/tests/test_site.py
@@ -202,17 +202,17 @@ class TestSite(unittest.TestCase):
 
         self.assertRegex(
             rendered,
-            r'location /assets \{\s+try_files \$uri =404;\s+'
-            r'add_header Cache-Control "max-age=31536000, immutable";\s+'
+            r"location /assets \{\s+try_files \$uri =404;\s+"
+            r"add_header Cache-Control \"max-age=31536000, immutable\";\s+"
             r"add_header Access-Control-Allow-Origin \$cors_origin_test_bench always;\s+"
-            r'add_header Access-Control-Allow-Methods \$cors_methods_test_bench always;\s+'
-            r'add_header Vary \$cors_vary_test_bench always;\s+'
-            r'if \(\$request_method = OPTIONS\) \{\s+'
-            r'add_header Access-Control-Allow-Origin \$cors_origin_test_bench always;\s+'
-            r'add_header Access-Control-Allow-Methods \$cors_methods_test_bench always;\s+'
-            r'add_header Access-Control-Max-Age 86400 always;\s+'
-            r'add_header Vary \$cors_vary_test_bench always;\s+'
-            r'return 204;',
+            r"add_header Access-Control-Allow-Methods \$cors_methods_test_bench always;\s+"
+            r"add_header Vary \$cors_vary_test_bench always;\s+"
+            r"if \(\$request_method = OPTIONS\) \{\s+"
+            r"add_header Access-Control-Allow-Origin \$cors_origin_test_bench always;\s+"
+            r"add_header Access-Control-Allow-Methods \$cors_methods_test_bench always;\s+"
+            r"add_header Access-Control-Max-Age 86400 always;\s+"
+            r"add_header Vary \$cors_vary_test_bench always;\s+"
+            r"return 204;",
         )
 
     def test_rendered_standalone_bench_nginx_adds_cors_headers_to_assets(self):
@@ -231,24 +231,24 @@ class TestSite(unittest.TestCase):
         self.assertIn('~^site\\.test:.*$ "*";', rendered)
         self.assertIn(
             (
-                'map $cors_origin_test_bench $cors_vary_test_bench {\n'
+                "map $cors_origin_test_bench $cors_vary_test_bench {\n"
                 '\t"" "";\n\t"*" "";\n\tdefault "Origin";\n}'
             ),
             rendered,
         )
         self.assertRegex(
             rendered,
-            r'location /assets \{\s+try_files \$uri =404;\s+'
-            r'add_header Cache-Control "max-age=31536000, immutable";\s+'
+            r"location /assets \{\s+try_files \$uri =404;\s+"
+            r"add_header Cache-Control \"max-age=31536000, immutable\";\s+"
             r"add_header Access-Control-Allow-Origin \$cors_origin_test_bench always;\s+"
-            r'add_header Access-Control-Allow-Methods \$cors_methods_test_bench always;\s+'
-            r'add_header Vary \$cors_vary_test_bench always;\s+'
-            r'if \(\$request_method = OPTIONS\) \{\s+'
-            r'add_header Access-Control-Allow-Origin \$cors_origin_test_bench always;\s+'
-            r'add_header Access-Control-Allow-Methods \$cors_methods_test_bench always;\s+'
-            r'add_header Access-Control-Max-Age 86400 always;\s+'
-            r'add_header Vary \$cors_vary_test_bench always;\s+'
-            r'return 204;',
+            r"add_header Access-Control-Allow-Methods \$cors_methods_test_bench always;\s+"
+            r"add_header Vary \$cors_vary_test_bench always;\s+"
+            r"if \(\$request_method = OPTIONS\) \{\s+"
+            r"add_header Access-Control-Allow-Origin \$cors_origin_test_bench always;\s+"
+            r"add_header Access-Control-Allow-Methods \$cors_methods_test_bench always;\s+"
+            r"add_header Access-Control-Max-Age 86400 always;\s+"
+            r"add_header Vary \$cors_vary_test_bench always;\s+"
+            r"return 204;",
         )
 
     def test_rendered_bench_nginx_omits_cors_when_no_origins(self):

--- a/agent/tests/test_site.py
+++ b/agent/tests/test_site.py
@@ -4,10 +4,11 @@ import json
 import os
 import shutil
 import unittest
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from agent.base import AgentException
-from agent.bench import Bench
+from agent.bench import Bench, _get_cors_origins
 from agent.server import Server
 from agent.site import Site
 
@@ -73,6 +74,33 @@ class TestSite(unittest.TestCase):
         server.benches_directory = self.benches_directory
         return Bench(self.bench_name, server)
 
+    def _render_bench_nginx(self, cors_origins, standalone=False):
+        output_file = os.path.join(self.test_dir, "nginx.conf")
+        with patch.object(Server, "__init__", new=lambda x: None):
+            server = Server()
+
+        context = {
+            "bench_name": self.bench_name,
+            "bench_name_slug": self.bench_name.replace("-", "_"),
+            "domain": "example.com",
+            "sites": [SimpleNamespace(name="site.test", host="site.test")],
+            "domains": {},
+            "http_timeout": 120,
+            "web_port": 8000,
+            "socketio_port": 9000,
+            "sites_directory": self.sites_directory,
+            "standalone": standalone,
+            "error_pages_directory": os.path.join(self.test_dir, "errors"),
+            "nginx_directory": os.path.join(self.test_dir, "nginx"),
+            "tls_protocols": None,
+            "code_server": {},
+            "cors_origins": cors_origins,
+        }
+        server._render_template("bench/nginx.conf.jinja2", context, output_file)
+
+        with open(output_file) as f:
+            return f.read()
+
     def test_rename_site_works_for_existing_site(self):
         """Ensure rename_site renames site."""
         bench = self._get_test_bench()
@@ -124,3 +152,108 @@ class TestSite(unittest.TestCase):
             bench.valid_sites[site_name]
         except KeyError:
             self.fail("Site not found in bench.sites")
+
+    def test_get_cors_origins_normalizes_string_defaults_and_overrides(self):
+        sites = [
+            SimpleNamespace(name="site-a.test", config={"domains": ["cdn.site-a.test"]}),
+            SimpleNamespace(
+                name="site-b.test",
+                config={"allow_cors": "https://portal.example.com"},
+            ),
+            SimpleNamespace(name="site-c.test", config={"allow_cors": []}),
+        ]
+
+        self.assertCountEqual(
+            _get_cors_origins(sites, "https://bench.example.com"),
+            [
+                ('"site-a.test:https://bench.example.com"', "$http_origin"),
+                ('"cdn.site-a.test:https://bench.example.com"', "$http_origin"),
+                ('"site-b.test:https://portal.example.com"', "$http_origin"),
+            ],
+        )
+
+    def test_get_cors_origins_supports_wildcard_values(self):
+        sites = [
+            SimpleNamespace(
+                name="site.test",
+                config={"domains": ["cdn.site.test"], "allow_cors": "*"},
+            )
+        ]
+
+        self.assertCountEqual(
+            _get_cors_origins(sites),
+            [
+                (r"~^site\.test:.*$", '"*"'),
+                (r"~^cdn\.site\.test:.*$", '"*"'),
+            ],
+        )
+
+    def test_rendered_bench_nginx_adds_cors_headers_to_assets(self):
+        rendered = self._render_bench_nginx(
+            _get_cors_origins(
+                [
+                    SimpleNamespace(
+                        name="site.test",
+                        config={"allow_cors": "https://portal.example.com"},
+                    )
+                ]
+            )
+        )
+
+        self.assertRegex(
+            rendered,
+            r'location /assets \{\s+try_files \$uri =404;\s+'
+            r'add_header Cache-Control "max-age=31536000, immutable";\s+'
+            r"add_header Access-Control-Allow-Origin \$cors_origin_test_bench always;\s+"
+            r'add_header Access-Control-Allow-Methods \$cors_methods_test_bench always;\s+'
+            r'add_header Vary \$cors_vary_test_bench always;\s+'
+            r'if \(\$request_method = OPTIONS\) \{\s+'
+            r'add_header Access-Control-Allow-Origin \$cors_origin_test_bench always;\s+'
+            r'add_header Access-Control-Allow-Methods \$cors_methods_test_bench always;\s+'
+            r'add_header Access-Control-Max-Age 86400 always;\s+'
+            r'add_header Vary \$cors_vary_test_bench always;\s+'
+            r'return 204;',
+        )
+
+    def test_rendered_standalone_bench_nginx_adds_cors_headers_to_assets(self):
+        rendered = self._render_bench_nginx(
+            _get_cors_origins(
+                [
+                    SimpleNamespace(
+                        name="site.test",
+                        config={"allow_cors": "*"},
+                    )
+                ]
+            ),
+            standalone=True,
+        )
+
+        self.assertIn('~^site\\.test:.*$ "*";', rendered)
+        self.assertIn(
+            (
+                'map $cors_origin_test_bench $cors_vary_test_bench {\n'
+                '\t"" "";\n\t"*" "";\n\tdefault "Origin";\n}'
+            ),
+            rendered,
+        )
+        self.assertRegex(
+            rendered,
+            r'location /assets \{\s+try_files \$uri =404;\s+'
+            r'add_header Cache-Control "max-age=31536000, immutable";\s+'
+            r"add_header Access-Control-Allow-Origin \$cors_origin_test_bench always;\s+"
+            r'add_header Access-Control-Allow-Methods \$cors_methods_test_bench always;\s+'
+            r'add_header Vary \$cors_vary_test_bench always;\s+'
+            r'if \(\$request_method = OPTIONS\) \{\s+'
+            r'add_header Access-Control-Allow-Origin \$cors_origin_test_bench always;\s+'
+            r'add_header Access-Control-Allow-Methods \$cors_methods_test_bench always;\s+'
+            r'add_header Access-Control-Max-Age 86400 always;\s+'
+            r'add_header Vary \$cors_vary_test_bench always;\s+'
+            r'return 204;',
+        )
+
+    def test_rendered_bench_nginx_omits_cors_when_no_origins(self):
+        rendered = self._render_bench_nginx([])
+
+        self.assertNotIn("cors_origin_test_bench", rendered)
+        self.assertNotIn("Access-Control-Allow-Origin", rendered)
+        self.assertNotIn("$request_method = OPTIONS", rendered)


### PR DESCRIPTION
## Summary
- read `allow_cors` from `site_config.json` and `common_site_config.json` when generating the bench nginx config
- generate site/domain-aware CORS origin mappings, including wildcard origin support and per-site overrides
- add CORS headers for public files and assets served directly by nginx, not just requests handled by the application
- add tests covering origin normalization, wildcard handling, bench defaults, site overrides, and the no-CORS case

## Why
CORS support currently depends on the application layer, which means public files served directly by nginx do not consistently return the expected headers. This change makes bench-level nginx output respect configured CORS settings for those responses as well.

## Disclaimer

Created based on a working nginx config from our prod system, without deep human knowledge of this repo, but with the assistance of 8 million tokens across all major LLM providers.