### PR TITLE
fix(restore-with-files): Include site config as part of restore

### DIFF
--- a/agent/bench.py
+++ b/agent/bench.py
@@ -447,7 +447,7 @@ class Bench(Base):
             self.drop_mariadb_user(name, mariadb_root_password, site_database)
 
     @step("Download Backup Files")
-    def download_files(self, name, database_url, public_url, private_url):
+    def download_files(self, name, database_url, public_url, private_url, config_url):
         download_directory = os.path.join(self.sites_directory, "downloads")
         if not os.path.exists(download_directory):
             os.mkdir(download_directory)
@@ -455,11 +455,13 @@ class Bench(Base):
         database_file = download_file(database_url, prefix=directory) if database_url else ""
         private_file = download_file(private_url, prefix=directory) if private_url else ""
         public_file = download_file(public_url, prefix=directory) if public_url else ""
+        config_file = download_file(config_url, prefix=directory) if config_url else ""
         return {
             "directory": directory,
             "database": database_file,
             "private": private_file,
             "public": public_file,
+            "config": config_file,
         }
 
     @step("Delete Downloaded Backup Files")

--- a/agent/bench.py
+++ b/agent/bench.py
@@ -447,7 +447,7 @@ class Bench(Base):
             self.drop_mariadb_user(name, mariadb_root_password, site_database)
 
     @step("Download Backup Files")
-    def download_files(self, name, database_url, public_url, private_url, config_url):
+    def download_files(self, name, database_url, public_url, private_url):
         download_directory = os.path.join(self.sites_directory, "downloads")
         if not os.path.exists(download_directory):
             os.mkdir(download_directory)
@@ -455,13 +455,11 @@ class Bench(Base):
         database_file = download_file(database_url, prefix=directory) if database_url else ""
         private_file = download_file(private_url, prefix=directory) if private_url else ""
         public_file = download_file(public_url, prefix=directory) if public_url else ""
-        config_file = download_file(config_url, prefix=directory) if config_url else ""
         return {
             "directory": directory,
             "database": database_file,
             "private": private_file,
             "public": public_file,
-            "config": config_file,
         }
 
     @step("Delete Downloaded Backup Files")

--- a/agent/site.py
+++ b/agent/site.py
@@ -198,10 +198,10 @@ class Site(Base):
         database,
         public,
         private,
-        config,
+        sanitized_config_content,
         skip_failing_patches,
     ):
-        files = self.bench.download_files(self.name, database, public, private, config)
+        files = self.bench.download_files(self.name, database, public, private)
         is_database_restoration_required = False
         try:
             if files["database"]:
@@ -213,14 +213,11 @@ class Site(Base):
                     files["public"],
                     files["private"],
                 )
-                
-                if not files.get("config"):
+
+                if not sanitized_config_content:
                     self.update_config()
                 else:
-                    sites_directory = self.bench.sites_directory
-                    site_config_path = files["config"].replace(sites_directory, "/home/frappe/frappe-bench/sites")
-                    with open(site_config_path) as f:
-                        self.update_config(f.read())
+                    self.update_config(sanitized_config_content)
             else:
                 self.restore_files(
                     public_file=files["public"],

--- a/agent/site.py
+++ b/agent/site.py
@@ -198,9 +198,10 @@ class Site(Base):
         database,
         public,
         private,
+        config,
         skip_failing_patches,
     ):
-        files = self.bench.download_files(self.name, database, public, private)
+        files = self.bench.download_files(self.name, database, public, private, config)
         is_database_restoration_required = False
         try:
             if files["database"]:
@@ -212,6 +213,14 @@ class Site(Base):
                     files["public"],
                     files["private"],
                 )
+                
+                if not files.get("config"):
+                    self.update_config()
+                else:
+                    sites_directory = self.bench.sites_directory
+                    site_config_path = files["config"].replace(sites_directory, "/home/frappe/frappe-bench/sites")
+                    with open(site_config_path) as f:
+                        self.update_config(f.read())
             else:
                 self.restore_files(
                     public_file=files["public"],

--- a/agent/site.py
+++ b/agent/site.py
@@ -206,6 +206,13 @@ class Site(Base):
         try:
             if files["database"]:
                 is_database_restoration_required = True
+
+                # Apply the backed up site config (e.g. backup_encryption_key)
+                # before restoring so `bench restore` can decrypt encrypted
+                # backups using the original site's encryption key.
+                if sanitized_config_content:
+                    self.update_config(sanitized_config_content)
+
                 self.restore_site(
                     mariadb_root_password,
                     admin_password,
@@ -213,11 +220,6 @@ class Site(Base):
                     files["public"],
                     files["private"],
                 )
-
-                if not sanitized_config_content:
-                    self.update_config()
-                else:
-                    self.update_config(sanitized_config_content)
             else:
                 self.restore_files(
                     public_file=files["public"],

--- a/agent/web.py
+++ b/agent/web.py
@@ -611,7 +611,7 @@ def restore_site(bench, site):
             data["database"],
             data.get("public"),
             data.get("private"),
-            data.get("config"),
+            data.get("sanitized_config_content"),
             data.get("skip_failing_patches", False),
         )
     )

--- a/agent/web.py
+++ b/agent/web.py
@@ -611,6 +611,7 @@ def restore_site(bench, site):
             data["database"],
             data.get("public"),
             data.get("private"),
+            data.get("config"),
             data.get("skip_failing_patches", False),
         )
     )


### PR DESCRIPTION
Resolves https://github.com/frappe/press/issues/2032

Site config download link was previously not being received by the restore endpoint nor being handled in case of restore with files site-action.

This requires pairing with https://github.com/frappe/press/pull/6441