### PR TITLE
refactor: Remove deprecated binlog endpoint

### DIFF
--- a/agent/database_server.py
+++ b/agent/database_server.py
@@ -237,46 +237,6 @@ WHERE `schema` IN (
         )
         mariadb.execute_sql("FLUSH TABLES;")
 
-    def search_binary_log(
-        self,
-        log,
-        database,
-        start_datetime,
-        stop_datetime,
-        search_pattern,
-        max_lines,
-    ):
-        log = os.path.join(self.mariadb_directory, log)
-        LINES_TO_SKIP = r"^(USE|COMMIT|START TRANSACTION|DELIMITER|ROLLBACK|#)"
-        command = (
-            f"mysqlbinlog --short-form --database {database} "
-            f"--start-datetime '{start_datetime}' "
-            f"--stop-datetime '{stop_datetime}' "
-            f" {log} | grep -Piv '{LINES_TO_SKIP}'"
-        )
-
-        DELIMITER = "/*!*/;"
-
-        events = []
-        timestamp = 0
-        for line in self.execute(command, skip_output_log=True)["output"].split(DELIMITER):
-            line = line.strip()
-            if line.startswith("SET TIMESTAMP"):
-                timestamp = int(line.split("=")[-1].split(".")[0])
-            else:
-                if any(line.startswith(skip) for skip in ["SET", "/*!"]):
-                    continue
-                if line and timestamp and re.search(search_pattern, line):
-                    events.append(
-                        {
-                            "query": line,
-                            "timestamp": str(datetime.utcfromtimestamp(timestamp)),
-                        }
-                    )
-                    if len(events) > max_lines:
-                        break
-        return events
-
     @property
     def binary_logs(self):
         BINARY_LOG_FILE_PATTERN = r"mysql-bin.\d+"

--- a/agent/web.py
+++ b/agent/web.py
@@ -1367,21 +1367,6 @@ def kill_database_processes():
     return jsonify(DatabaseServer().kill_processes(**data))
 
 
-@application.route("/database/binary/logs/<string:log>", methods=["POST"])
-def get_binary_log(log):
-    data = request.json
-    return jsonify(
-        DatabaseServer().search_binary_log(
-            log,
-            data["database"],
-            data["start_datetime"],
-            data["stop_datetime"],
-            data["search_pattern"],
-            data["max_lines"],
-        )
-    )
-
-
 @application.route("/database/stalks")
 def get_stalks():
     return jsonify(DatabaseServer().get_stalks())


### PR DESCRIPTION
In binlog v2, we have our custom indexer