### PR TITLE
feat(storage-breakdown): Include archived benches size

### DIFF
--- a/agent/server.py
+++ b/agent/server.py
@@ -967,6 +967,9 @@ class Server(Base):
         total_output = self.execute(
             f"df -B1 {'/opt/volumes/benches' if os.path.exists('/opt/volumes/benches') else '/'}"
         ).get("output")
+        archived_output = self.execute(
+            "du -sB1 /home/frappe/archived/ --exclude assets | awk '{print $1}'"
+        ).get("output")
 
         if total_output:
             total_data = parse_total_disk_usage_output(total_output)
@@ -980,6 +983,13 @@ class Server(Base):
         if docker_output:
             docker_data = parse_docker_df_output(docker_output)
             app_storage_analysis["docker"] = docker_data
+
+        if archived_output:
+            archived_size = int(float(archived_output))
+            app_storage_analysis["archived"] = {
+                "size": archived_size,
+                "size_formatted": format_size(archived_size),
+            }
 
         return app_storage_analysis or {"error": failed_message}
 


### PR DESCRIPTION
## What

`get_storage_breakdown()` returned `benches`, `docker` and `total`, but not the archived benches directory (`/home/frappe/archived`). This adds an `archived` bucket.

## Why

On unified servers, Press's Database Server storage breakdown computes OS usage as `disk_used - total_db_usage` — a residual that absorbs everything non-MariaDB on the shared disk, including archived benches. A server with 54 GB of archived benches reported 59 GB of "Operating System" usage.

To break archived usage out of that OS bucket, Press needs the archived size, and it derives it from this endpoint (`Server.get_storage_usage`) rather than making a separate ansible call.

## How

Measured the same way `get_reclaimable_size` already does (`du -sB1 --exclude assets`), so the number stays consistent with what "Cleanup Unused Files" reclaims.

## Companion change

Consumed by frappe/press#6685.

🤖 Generated with [Claude Code](https://claude.com/claude-code)