### PR TITLE
perf(site): Avoid file-tree walk when only database usage is needed

### DIFF
--- a/agent/site.py
+++ b/agent/site.py
@@ -849,11 +849,11 @@ class Site(Base):
     def get_timezone(self):
         return self.timezone
 
-    def fetch_site_info(self):
+    def fetch_site_info(self, database_only=False):
         return {
             "config": self.config,
             "timezone": self.get_timezone(),
-            "usage": self.get_usage(),
+            "usage": self.get_usage(database_only=database_only),
         }
 
     def fetch_site_analytics(self):
@@ -1404,8 +1404,13 @@ print(">>>" + frappe.session.sid + "<<<")
 
         return backups
 
-    def get_usage(self):
+    def get_usage(self, database_only=False):
         """Returns Usage in bytes"""
+        if database_only:
+            # Skip the recursive file-size walk; callers refreshing only the
+            # database size don't need (and time out on) the file totals.
+            return {"database": b2mb(self.get_database_size())}
+
         backup_directory = os.path.join(self.directory, "private", "backups")
         public_directory = os.path.join(self.directory, "public")
         private_directory = os.path.join(self.directory, "private")

--- a/agent/site.py
+++ b/agent/site.py
@@ -1407,8 +1407,7 @@ print(">>>" + frappe.session.sid + "<<<")
     def get_usage(self, database_only=False):
         """Returns Usage in bytes"""
         if database_only:
-            # Skip the recursive file-size walk; callers refreshing only the
-            # database size don't need (and time out on) the file totals.
+            # Only the database size is needed; skip the file-size walk.
             return {"database": b2mb(self.get_database_size())}
 
         backup_directory = os.path.join(self.directory, "private", "backups")

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -82,25 +82,20 @@ def download_file(url, prefix):
 
 
 def get_size(folder, ignore_dirs=None):
-    """Returns the size of the folder in bytes. Ignores symlinks"""
-    total_size = os.path.getsize(folder)
+    """Returns the apparent size of the folder in bytes.
 
-    if ignore_dirs is None:
-        ignore_dirs = []
+    Shells out to `du` (C) instead of walking the tree in Python: a recursive
+    Python stat of every file was timing out gunicorn workers on sites with
+    large file trees. `du -b` reports apparent size (st_size), matching the
+    old behaviour. ignore_dirs is applied at the top level only, as before.
+    """
+    command = ["du", "-sb"]
+    for ignored in ignore_dirs or []:
+        command += ["--exclude", ignored]
+    command.append(folder)
 
-    for item in os.listdir(folder):
-        itempath = os.path.join(folder, item)
-
-        if item in ignore_dirs:
-            continue
-
-        if not os.path.islink(itempath):
-            if os.path.isfile(itempath):
-                total_size += os.path.getsize(itempath)
-            elif os.path.isdir(itempath):
-                total_size += get_size(itempath)
-
-    return total_size
+    output = subprocess.check_output(command, text=True)
+    return int(output.split(maxsplit=1)[0])
 
 
 def is_registry_healthy(url: str, username: str, password: str) -> bool:

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -82,12 +82,10 @@ def download_file(url, prefix):
 
 
 def get_size(folder, ignore_dirs=None):
-    """Returns the apparent size of the folder in bytes.
+    """Returns the apparent size of the folder in bytes, ignoring symlinks.
 
-    Shells out to `du` (C) instead of walking the tree in Python: a recursive
-    Python stat of every file was timing out gunicorn workers on sites with
-    large file trees. `du -b` reports apparent size (st_size), matching the
-    old behaviour. ignore_dirs is applied at the top level only, as before.
+    Uses `du -sb` (apparent size, matching the old walk). ignore_dirs is
+    applied at the top level only, as before.
     """
     command = ["du", "-sb"]
     for ignored in ignore_dirs or []:

--- a/agent/web.py
+++ b/agent/web.py
@@ -744,7 +744,8 @@ def fetch_site_status(bench, site):
 @application.route("/benches/<string:bench>/sites/<string:site>/info", methods=["GET"])
 @validate_bench_and_site
 def fetch_site_info(bench, site):
-    return {"data": Server().benches[bench].sites[site].fetch_site_info()}
+    database_only = request.args.get("database_only") in ("1", "true", "True")
+    return {"data": Server().benches[bench].sites[site].fetch_site_info(database_only=database_only)}
 
 
 @application.route("/benches/<string:bench>/sites/<string:site>/analytics", methods=["GET"])


### PR DESCRIPTION
**Paired PR:** frappe/press#6765

## Problem

`get_usage` (served by the `/info` endpoint) always computes full disk usage, including a recursive walk of the site's `public`, `private`, and `backups` directories to sum file sizes. On sites with large file trees this walk exceeds the gunicorn timeout and kills agent web workers (`WORKER TIMEOUT`).

Press's "refresh database usage" polls `/info` frequently but only needs the database size — yet pays for the whole file walk each time.

## Changes

**1. `du -sb` instead of a Python walk** (`get_size`)
The old `get_size` ran `islink`/`isfile`/`isdir`/`getsize` per entry — several stat syscalls per file. Shelling to `du -sb` does the same apparent-size sum in C with one stat per file. `ignore_dirs` maps to `du --exclude`.

**2. `database_only` flag** (`/info` route → `fetch_site_info` → `get_usage`)
The `/info` route accepts `?database_only=1`; in that mode `get_usage` returns only the (cheap) database size and skips the file walks entirely.

## Relationship to prior work

Complements the DB-size optimizations in #399 / #447 / #364, which made the *database* portion cheap but left the `public/private/backups` file walk in place. This skips that walk for callers that don't need it.

## Paired change

frappe/press#6765 sends `?database_only=1` from the database-usage refresh path. The two can deploy in either order — an older Press simply omits the param and gets the full walk (current behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
