### PR TITLE
feat(restore): add --verbose flag to restore_site command

### DIFF
--- a/agent/site.py
+++ b/agent/site.py
@@ -131,6 +131,7 @@ class Site(Base):
         try:
             return self.bench_execute(
                 "--force restore "
+                "--verbose "
                 f"--mariadb-root-username {temp_user} "
                 f"--mariadb-root-password {temp_password} "
                 f"--admin-password {admin_password} "

--- a/agent/tests/test_site.py
+++ b/agent/tests/test_site.py
@@ -322,6 +322,7 @@ class TestSite(unittest.TestCase):
                 private_file="/path/to/private_files.tar",
             )
 
+        mock_execute.assert_called_once()
         command = mock_execute.call_args[0][0]
         self.assertIn("--force restore", command)
         self.assertIn("--verbose", command)

--- a/agent/tests/test_site.py
+++ b/agent/tests/test_site.py
@@ -301,3 +301,27 @@ class TestSite(unittest.TestCase):
                 ('"cdn.site.test:https://portal.example.com"', "$http_origin"),
             ],
         )
+
+    def test_restore_site_passes_verbose_flag(self):
+        """Ensure restore_site includes --verbose in the bench command."""
+        bench = self._get_test_bench()
+        site_name = "restore-site.frappe.cloud"
+        self._create_test_site(site_name)
+        self._make_site_config(site_name)
+
+        site = Site(site_name, bench)
+        with patch.object(site, "bench_execute") as mock_execute, patch.object(
+            bench, "create_mariadb_user", return_value=(None, "temp_user", "temp_pass")
+        ), patch.object(bench, "drop_mariadb_user"):
+            Site.restore_site.__wrapped__(
+                site,
+                mariadb_root_password="root_pass",
+                admin_password="admin_pass",
+                database_file="/path/to/database.sql.gz",
+                public_file="/path/to/public_files.tar",
+                private_file="/path/to/private_files.tar",
+            )
+
+        command = mock_execute.call_args[0][0]
+        self.assertIn("--force restore", command)
+        self.assertIn("--verbose", command)


### PR DESCRIPTION
Adds --verbose to the bench restore command so users can see progress during heavy backup restores instead of waiting with a single static message.

Also addresses the Greptile review note: add mock_execute.assert_called_once() before accessing call_args so a failure to reach bench_execute produces a clear assertion error rather than a confusing TypeError.

Closes frappe/agent#483.