### PR TITLE
fix(job): make job timeout configurable via request param (backport to master)

### DIFF
--- a/agent/job.py
+++ b/agent/job.py
@@ -36,7 +36,7 @@ if os.environ.get("SENTRY_DSN"):
     except ImportError:
         pass
 
-
+DEFAULT_TIMEOUT = 4 * 3600
 agent_database = SqliteDatabase(
     "jobs.sqlite3",
     timeout=15,
@@ -176,10 +176,13 @@ def step(name):
     return wrapper
 
 
-def job(name: str, priority="default", on_success=None, on_failure=None):
+def job(name: str, priority="default", timeout=None, on_success=None, on_failure=None):
     @wrapt.decorator
     def wrapper(wrapped, instance: Base, args, kwargs):
+        from flask import has_request_context, request
+
         from agent.base import AgentException
+        from agent.server import Server
 
         if get_current_job(connection=connection()):
             instance.job_record.start()
@@ -195,12 +198,20 @@ def job(name: str, priority="default", on_success=None, on_failure=None):
                 instance.job_record.success(result)
             return result
         agent_job_id = get_agent_job_id()
+        agent_job_timeout = None
+        if has_request_context() and request and request.is_json:
+            agent_job_timeout = request.json.get("agent_job_timeout", None)
         instance.job_record.enqueue(name, wrapped, args, kwargs, agent_job_id)
+        final_timeout = (
+            agent_job_timeout or timeout or Server().config.get("job_timeout", None) or DEFAULT_TIMEOUT
+        )
+        if not 0 <= final_timeout <= 24 * 3600:
+            final_timeout = DEFAULT_TIMEOUT
         queue(priority).enqueue_call(
             wrapped,
             args=args,
             kwargs=kwargs,
-            timeout=4 * 3600,
+            timeout=final_timeout,
             result_ttl=24 * 3600,
             job_id=str(instance.job_record.model.id),
             on_success=on_success or callback,


### PR DESCRIPTION
## Backport

Backports the configurable job-timeout feature from `develop` (commit `f06c9a9`, *"fix(job): Make job timeout configurable so that job can pass as param"*) onto `master`.

## Why

The `@job` decorator in `agent/job.py` hardcoded the RQ `job_timeout` to `4 * 3600` (4h) for **every** job. Long-running jobs — notably the new **streaming offsite backup** flow — were SIGKILLed by the RQ work-horse exactly 4h in, even though the endpoint (Press) requests a longer timeout (e.g. 18000s). The requested value was never consumed by the agent.

## What changed

`agent/job.py` only:
- `job(...)` gains an optional `timeout` param.
- The decorator reads `agent_job_timeout` from the request JSON body when present.
- Resolves the effective timeout as: `agent_job_timeout` → decorator `timeout` → `Server().config["job_timeout"]` → `DEFAULT_TIMEOUT` (4h), clamped to `[0, 24h]`.
- `enqueue_call` now uses the resolved value instead of the hardcoded `4 * 3600`.

No `web.py` changes are needed — the decorator reads the timeout generically, so all endpoints (including `/backup`) benefit.

## Notes

- This is a faithful backport of the develop behavior; the string-coercion hardening discussed separately was omitted since `agent_job_timeout` is always sent as a number.
- Fixes the 4h streaming-backup kill once deployed to servers running `master`.