### PR TITLE
fix(backup): support custom S3 endpoint URL for offsite backup

### DIFF
--- a/agent/site.py
+++ b/agent/site.py
@@ -659,7 +659,7 @@ class Site(Base):
             if region:
                 client_kwargs["region_name"] = region.strip()
             if auth.get("ENDPOINT_URL"):
-                client_kwargs["endpoint_url"] = auth["ENDPOINT_URL"]
+                client_kwargs["endpoint_url"] = auth["ENDPOINT_URL"].strip()
 
             s3 = boto3.client("s3", **client_kwargs)
 

--- a/agent/site.py
+++ b/agent/site.py
@@ -651,19 +651,17 @@ class Site(Base):
             )
             region = auth.get("REGION")
 
+            client_kwargs = {
+                "aws_access_key_id": auth["ACCESS_KEY"],
+                "aws_secret_access_key": auth["SECRET_KEY"],
+            }
+
             if region:
-                s3 = boto3.client(
-                    "s3",
-                    aws_access_key_id=auth["ACCESS_KEY"],
-                    aws_secret_access_key=auth["SECRET_KEY"],
-                    region_name=region,
-                )
-            else:
-                s3 = boto3.client(
-                    "s3",
-                    aws_access_key_id=auth["ACCESS_KEY"],
-                    aws_secret_access_key=auth["SECRET_KEY"],
-                )
+                client_kwargs["region_name"] = region.strip()
+            if auth.get("ENDPOINT_URL"):
+                client_kwargs["endpoint_url"] = auth["ENDPOINT_URL"]
+
+            s3 = boto3.client("s3", **client_kwargs)
 
             for backup_file in backup_files.values():
                 file_name = backup_file["file"].split(os.sep)[-1]


### PR DESCRIPTION
## Summary
- Support custom S3 endpoint URL (`ENDPOINT_URL`) for offsite backup uploads
- Strip whitespace from region config before passing to boto3
- Refactor S3 client initialization to use shared `client_kwargs`
## Problem
Offsite backup upload fails for S3-compatible storage (MinIO, etc.)
because boto3 client was created without `endpoint_url`.
## Test plan
- [ ] Offsite backup upload works with AWS S3 (no endpoint_url)
- [ ] Offsite backup upload works with S3-compatible provider (with ENDPOINT_URL set)
- [ ] Region with trailing whitespace is handled correctly