### PR TITLE
fix(bench): write config.json atomically to prevent silent 404s

### DIFF
--- a/agent/bench.py
+++ b/agent/bench.py
@@ -988,23 +988,28 @@ class Bench(Base):
 
     def set_bench_config(self, value, indent=1):
         """
-        To avoid partial writes, we need to first write the config to a temporary file,
-        then rename it to the original file.
+        Write the config atomically: dump to a temp file in the same directory,
+        fsync it, then os.replace() it onto config.json.
+
+        The temp file must live on the same filesystem as the target, otherwise
+        os.replace() fails with EXDEV. A previous version wrote the temp file to
+        /tmp and finished with shutil.copy2(), which truncates config.json before
+        streaming into it -- an interrupted write there left a 0-byte config.json
+        and made the bench silently disappear (BenchNotExistsException -> 404).
         """
-        with tempfile.NamedTemporaryFile(mode="w", delete=False) as temp_file:
-            json.dump(value, temp_file, indent=indent, sort_keys=True)
-            temp_file.flush()
-            os.fsync(temp_file.fileno())
-            temp_file.close()
-
-        os.rename(self.bench_config_file, self.bench_config_file + ".bak")
-
+        fd, temp_path = tempfile.mkstemp(
+            dir=self.directory, prefix=".config.", suffix=".json"
+        )
         try:
-            shutil.copy2(temp_file.name, self.bench_config_file)
-            os.remove(temp_file.name)
-        except Exception as e:
-            os.rename(self.bench_config_file + ".bak", self.bench_config_file)
-            raise e
+            with os.fdopen(fd, "w") as temp_file:
+                json.dump(value, temp_file, indent=indent, sort_keys=True)
+                temp_file.flush()
+                os.fsync(temp_file.fileno())
+            os.replace(temp_path, self.bench_config_file)
+        except Exception:
+            with suppress(FileNotFoundError):
+                os.remove(temp_path)
+            raise
 
     @job("Patch App")
     def patch_app(

--- a/agent/server.py
+++ b/agent/server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import logging
 import os
 import platform
 import shlex
@@ -32,6 +33,8 @@ from agent.nfs_handler import NFSHandler
 from agent.patch_handler import run_patches
 from agent.site import Site
 from agent.utils import get_supervisor_processes_status, is_registry_healthy
+
+logger = logging.getLogger(__name__)
 
 
 class Server(Base):
@@ -95,8 +98,21 @@ class Server(Base):
             os.mkdir(os.path.join(bench_directory, directory))
 
         bench_config_file = os.path.join(bench_directory, "config.json")
-        with open(bench_config_file, "w") as f:
-            json.dump(config, f, indent=1, sort_keys=True)
+        # Write atomically so an interrupted New Bench job can never leave a
+        # 0-byte config.json behind (which makes the bench silently 404).
+        fd, temp_path = tempfile.mkstemp(
+            dir=bench_directory, prefix=".config.", suffix=".json"
+        )
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(config, f, indent=1, sort_keys=True)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(temp_path, bench_config_file)
+        except Exception:
+            with suppress(FileNotFoundError):
+                os.remove(temp_path)
+            raise
 
         config.update({"directory": bench_directory, "name": name})
         docker_compose = os.path.join(bench_directory, "docker-compose.yml")
@@ -844,8 +860,14 @@ class Server(Base):
     def benches(self) -> dict[str, Bench]:
         benches = {}
         for directory in os.listdir(self.benches_directory):
-            with suppress(Exception):
+            try:
                 benches[directory] = Bench(directory, self)
+            except Exception:
+                # A bench that fails to construct (e.g. missing/corrupt
+                # config.json) is skipped, which surfaces downstream as an
+                # opaque BenchNotExistsException -> 404. Log it so the real
+                # cause is diagnosable instead of silently swallowed.
+                logger.exception("Skipping bench %s: failed to load", directory)
         return benches
 
     def get_bench(self, bench):


### PR DESCRIPTION
## Problem

A bench that clearly exists on disk was returning `404` for every request:

```
agent.exceptions.BenchNotExistsException: Bench bench-9052-000094-f16j does not exist
  File ".../agent/bench.py", line 61, in __init__
    self.docker_image = self.bench_config.get("docker_image")
  ...
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

On the server, `config.json` was **0 bytes** while a valid `config.json.bak` sat right next to it.

## Root cause

`set_bench_config` claimed to avoid partial writes by writing to a temp file first, but its final step used `shutil.copy2(temp, config.json)`. `copy2` opens the destination with `open(dst, "wb")`, which **truncates `config.json` to 0 bytes** and then streams into it. If the process dies in that window (OOM kill, worker/supervisor restart, deploy), you're left with a 0-byte `config.json` + a valid `.bak`.

`Bench.__init__` then raises on `json.load` (at `bench.py:61`, before the existence guard), and `Server.benches` swallowed the exception via `suppress(Exception)` — so the bench silently disappeared from the dict and `get_bench` raised `BenchNotExistsException` → `404`, with no hint of the real cause.

The temp file lived in `/tmp` (a different filesystem), which is why `copy2` was used instead of an atomic `os.replace` — the latter fails with `EXDEV` across filesystems.

## Fix

- **`set_bench_config`**: write the temp file in the bench directory via `tempfile.mkstemp(dir=self.directory)`, `fsync`, then `os.replace` onto `config.json` — an atomic same-filesystem rename with no truncation window. Removes the `copy2`/`.bak` dance.
- **`bench_init`**: the initial `config.json` write for a new bench used `open("w")` (truncates immediately) — made atomic the same way, so an interrupted **New Bench** job can't leave a 0-byte stub.
- **`Server.benches`**: replace `suppress(Exception)` with a `try/except` that `logger.exception`s the skipped bench, so a corrupt config is diagnosable from logs instead of an opaque 404.

## Testing

- Both files compile.
- Smoke-tested the atomic-write logic standalone: correct content, clean overwrite, no zero-byte window, no leftover temp files.

## Recovering affected benches

For any bench already in this state, the good config is in the backup:

```bash
cd /home/frappe/benches/<bench-name>
install -o frappe -g frappe -m 600 config.json.bak config.json
```