### PR TITLE
feat(proxy): Recover real client IP for Cloudflare-fronted traffic

### DIFF
--- a/agent/templates/proxy/nginx.conf.jinja2
+++ b/agent/templates/proxy/nginx.conf.jinja2
@@ -1,3 +1,30 @@
+# Recover the real client IP for traffic arriving via Cloudflare.
+# Only connections from these ranges are trusted; direct traffic is untouched.
+# Ranges from https://www.cloudflare.com/ips-v4 and https://www.cloudflare.com/ips-v6
+set_real_ip_from 173.245.48.0/20;
+set_real_ip_from 103.21.244.0/22;
+set_real_ip_from 103.22.200.0/22;
+set_real_ip_from 103.31.4.0/22;
+set_real_ip_from 141.101.64.0/18;
+set_real_ip_from 108.162.192.0/18;
+set_real_ip_from 190.93.240.0/20;
+set_real_ip_from 188.114.96.0/20;
+set_real_ip_from 197.234.240.0/22;
+set_real_ip_from 198.41.128.0/17;
+set_real_ip_from 162.158.0.0/15;
+set_real_ip_from 104.16.0.0/13;
+set_real_ip_from 104.24.0.0/14;
+set_real_ip_from 172.64.0.0/13;
+set_real_ip_from 131.0.72.0/22;
+set_real_ip_from 2400:cb00::/32;
+set_real_ip_from 2606:4700::/32;
+set_real_ip_from 2803:f800::/32;
+set_real_ip_from 2405:b500::/32;
+set_real_ip_from 2405:8100::/32;
+set_real_ip_from 2a06:98c0::/29;
+set_real_ip_from 2c0f:f248::/32;
+real_ip_header CF-Connecting-IP;
+
 map $host $subdomain_map {
     ~^(?<subdomain>[^.]*).*$ $subdomain.{{ domain }};
 }

--- a/agent/tests/test_proxy.py
+++ b/agent/tests/test_proxy.py
@@ -255,6 +255,30 @@ class TestProxy(unittest.TestCase):
         with open(redirect_file) as r:
             self.assertDictEqual(json.load(r), original_dict)
 
+    def test_generated_proxy_config_recovers_real_client_ip_from_cloudflare(self):
+        """Test proxy.conf trusts Cloudflare ranges for realip before any server block."""
+        proxy = self._get_fake_proxy()
+        proxy.upstreams_directory = self.upstreams_directory
+        proxy.error_pages_directory = os.path.join(self.test_dir, "pages")
+        proxy.secondary_config_path = os.path.join(self.test_dir, "secondaries.json")
+
+        upstream_directory = os.path.join(self.upstreams_directory, "10.0.0.1")
+        os.makedirs(upstream_directory)
+        with open(os.path.join(upstream_directory, "site.frappe.cloud"), "w") as f:
+            f.write("active")
+
+        config = {"domain": self.tld, "nginx_directory": proxy.nginx_directory}
+        with patch.object(Proxy, "get_config", return_value=config):
+            proxy._generate_proxy_config()
+
+        with open(os.path.join(proxy.nginx_directory, "proxy.conf")) as f:
+            rendered = f.read()
+
+        self.assertIn("real_ip_header CF-Connecting-IP;", rendered)
+        first_server_block = rendered.index("server {")
+        self.assertLess(rendered.index("set_real_ip_from 173.245.48.0/20;"), first_server_block)
+        self.assertLess(rendered.index("set_real_ip_from 2400:cb00::/32;"), first_server_block)
+
     def test_rename_does_not_update_partial_strings(self):
         """Test rename doesn't update part of other custom domains."""
         proxy = self._get_fake_proxy()


### PR DESCRIPTION
Traffic arriving via Cloudflare has $remote_addr set to the Cloudflare edge IP, so proxy logs, rate limiting and everything downstream see Cloudflare instead of the client. Trust Cloudflare's published ranges and take the client address from CF-Connecting-IP.

Only the proxy needs this: app servers already trust the proxy via realip on X-Real-IP (templates/nginx/nginx.conf.jinja2), and all proxy location blocks already forward X-Real-IP and X-Forwarded-For from $remote_addr, so the recovered address propagates to benches and Frappe unchanged.

The ranges are hardcoded from https://www.cloudflare.com/ips-v4 and /ips-v6 (fetched 2026-07-13). They change rarely and agent releases are the natural refresh vehicle. Spoofing is not possible: realip only rewrites connections originating from the listed ranges, and Cloudflare always overwrites CF-Connecting-IP itself.

Verified in docker (nginx:1.27-alpine, source IP inside a Cloudflare range): header from trusted range rewrites $remote_addr; spoofed header from an untrusted source is ignored; missing or garbage header leaves the connection address untouched.