### PR TITLE
fix(build): fall back when python3.14 is missing on builder

### DIFF
--- a/agent/build_utils/validations.py
+++ b/agent/build_utils/validations.py
@@ -161,12 +161,13 @@ def get_python_path(dirpath: str) -> str:
             if requires_python:
                 version_spec = sv.SimpleSpec(requires_python)
                 if version_spec.match(sv.Version("3.14.0")):
-                    # try to resolve python3.14 path
-                    python_path = shutil.which("python3.14")
-                    if python_path:
-                        return python_path
-                    # Temporary hardcoding until python 3.14 until we move to build server
-                    return "/usr/bin/python3.14"
+                    # Prefer a real python3.14 binary when present
+                    for candidate in (shutil.which("python3.14"), "/usr/bin/python3.14"):
+                        if candidate and os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+                            return candidate
+                    # Spec matches 3.14 but no interpreter on this host (common on
+                    # Frappe 14/15 build images). Falling back avoids FileNotFoundError
+                    # during Pre-build compileall, which surfaces as empty step output.
 
     return _get_server_python_path()
 


### PR DESCRIPTION
## Summary
- `get_python_path` only returns a python3.14 path when that interpreter actually exists on the builder
- Otherwise falls back to the agent/server Python (same as apps that do not match 3.14)
- Prevents Pre-build `compileall` from raising `FileNotFoundError` (Press UI shows empty Pre-build output) when Frappe v14 apps declare `requires-python = \">=3.10\"` on hosts without python3.14

## Context
Seen on Frappe Cloud `bench-42251` (PYTHON_VERSION 3.10, Frappe v14.101.1): Clone succeeds, **Run Validations – Pre-build** fails with output length 0. CRM already pins `>=3.10,<3.14`; framework `>=3.10` still routes validation onto the hardcoded 3.14 path.

## Test plan
- [ ] Unit/manual: pyproject with `requires-python = \">=3.10\"` on a host **without** `/usr/bin/python3.14` → `get_python_path` returns server python; `check_python_syntax` does not raise `FileNotFoundError`
- [ ] Host **with** python3.14 on PATH → still selects that binary
- [ ] App with `requires-python = \">=3.10,<3.14\"` → unchanged (server python)

Made with [Cursor](https://cursor.com)