### PR TITLE
fix(bench): Pass build-relevant env into SSH sessions

### DIFF
--- a/agent/build_configs/config/ssh/sshd_config
+++ b/agent/build_configs/config/ssh/sshd_config
@@ -33,7 +33,7 @@ TrustedUserCAKeys /home/frappe/frappe-bench/config/ssh/ca.pub
 AuthorizedPrincipalsFile /home/frappe/frappe-bench/config/ssh/principals
 
 HostKey /home/frappe/frappe-bench/config/ssh/ssh_host_rsa_key
-HostCertificate /home/frappe/frappe-bench/config/ssh/ssh_host_rsa_key-cert.pub 
+HostCertificate /home/frappe/frappe-bench/config/ssh/ssh_host_rsa_key-cert.pub
 
 
 # Capability Limits
@@ -49,6 +49,11 @@ PermitOpen none
 PermitTunnel no
 PermitUserEnvironment no
 PermitUserRC no
+
+# sshd drops the image's ENV, so `bench build` over SSH symlinks assets.
+# Must stay on one line -- sshd keeps only the first SetEnv it reads.
+# PATH is left alone on purpose, it embeds the node version.
+SetEnv FRAPPE_HARD_LINK_ASSETS=True LANG=C.UTF-8 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 PYTHONUNBUFFERED=1 HISTTIMEFORMAT="%Y-%m-%d %T "
 
 PrintMotd no
 


### PR DESCRIPTION
`echo $FRAPPE_HARD_LINK_ASSETS` inside a bench over SSH comes back empty, even though the image sets it.

sshd builds a fresh environment for each session rather than inheriting its parent's. This config sets `UsePAM no` (so no `/etc/environment`) and `PermitUserEnvironment no` (so no `~/.ssh/environment`), which leaves nothing to carry the image's `ENV` through. Result: a manual `bench build` over SSH **symlinks** assets, while the identical command via `docker exec` (agent's `Rebuild Bench Assets`) hard-links them.

Added a `SetEnv` line with the vars that are safe and meaningful in a shell session.

### Two things worth knowing

**`SetEnv` does not merge across lines.** sshd keeps only the *first* one it reads — the "first obtained value wins" rule. Verified:

```
SetEnv A=1 / SetEnv B=2 / SetEnv C=3   ->  setenv A=1          (B and C silently dropped)
SetEnv A=1 B=2 C=3                     ->  setenv A=1 B=2 C=3
```

Hence the single long line. Anyone adding a var later must append to it, not add a line — the comment says so.

**`PATH` is deliberately excluded.** The image builds it as `$PATH:/home/frappe/.nvm/versions/node/v${NODE_VERSION}/bin`, and the node version isn't known to this static file. SSH sessions still won't find `node`/`yarn` — separate problem, not fixed here.

Config parses clean under `sshd -T`, and the trailing space in `HISTTIMEFORMAT` survives (it's inside the quotes).

### Rollout

`Bench.start()` bind-mounts the host's `config/` over the image's, and that host copy is seeded once at `bench_init` via `docker run ... cp -LR config/. configmount`. So this reaches **new benches only** — existing benches keep their baked-in `sshd_config` until they're recreated.

### Related

Companion fix in press for the image-build side of the same symptom: https://github.com/frappe/press/pull/7076

🤖 Generated with [Claude Code](https://claude.com/claude-code)