### PR TITLE
feat(database-server): Upload MariaDB audit logs to S3

### DIFF
--- a/agent/database_server.py
+++ b/agent/database_server.py
@@ -919,16 +919,23 @@ WHERE `schema` IN (
             destination = os.path.join(
                 self.audit_log_pending_directory, f"server_audit_{rotated_at}_{index}.log"
             )
-            # os.rename overwrites silently. Refuse rather than lose an audit log.
-            if os.path.exists(destination):
-                raise FileExistsError(f"Staged audit log already exists: {destination}")
-            os.rename(source, destination)
+            # os.rename clobbers silently, and checking first leaves a window where an
+            # overlapping job replaces the path and we later delete a log we never
+            # uploaded. os.link refuses an existing destination atomically.
+            os.link(source, destination)
+            os.unlink(source)
             staged.append(os.path.basename(destination))
 
         return {"staged_files": staged}
 
     @step("Upload Audit Logs To S3")
     def upload_audit_logs_to_s3(self, offsite: dict) -> dict:
+        """Upload every staged audit log, then delete it from disk.
+
+        Returns {"offsite_files": {name: {size, uncompressed_size, path,
+        start_timestamp, end_timestamp}}, "failed_uploads": {name: error}}. Press turns
+        each offsite_files entry into a MariaDB Audit Log record.
+        """
         import boto3
 
         offsite_files = {}

--- a/agent/database_server.py
+++ b/agent/database_server.py
@@ -18,6 +18,12 @@ from agent.database import CustomPeeweeDB, Database
 from agent.job import job, step
 from agent.server import Server
 
+# server_audit rotates server_audit.log to .1, .1 to .2 and so on. We move those to
+# audit_pending under a name that can't be reused, then upload and delete from there.
+AUDIT_LOG_ROTATED_RE = re.compile(r"^server_audit\.log\.\d+$")
+AUDIT_LOG_STAGED_RE = re.compile(r"^server_audit_\d{14}_\d+\.log$")
+AUDIT_LOG_RECORD_RE = re.compile(r"^\d{8} \d{2}:\d{2}:\d{2},")
+
 
 class DatabaseServer(Server):
     def __init__(self, directory=None):
@@ -29,6 +35,8 @@ class DatabaseServer(Server):
 
         self.mariadb_directory = "/var/lib/mysql"
         self.pt_stalk_directory = "/var/lib/pt-stalk"
+        self.audit_log_directory = "/var/log/mysql"
+        self.audit_log_pending_directory = os.path.join(self.audit_log_directory, "audit_pending")
 
         self.job = None
         self.step = None
@@ -880,6 +888,111 @@ WHERE `schema` IN (
             "failed_uploads": failed_uploads,
         }
 
+    def get_audit_logs(self) -> dict:
+        return {
+            "rotated": list_audit_logs(self.audit_log_directory, AUDIT_LOG_ROTATED_RE),
+            "pending_upload": list_audit_logs(self.audit_log_pending_directory, AUDIT_LOG_STAGED_RE),
+        }
+
+    @job("Upload Audit Logs To S3", priority="low")
+    def upload_audit_logs_to_s3_job(self, private_ip: str, mariadb_root_password: str, offsite: dict) -> dict:
+        self.stage_audit_logs(private_ip, mariadb_root_password)
+        return self.upload_audit_logs_to_s3(offsite)
+
+    @step("Rotate Audit Log")
+    def stage_audit_logs(self, private_ip: str, mariadb_root_password: str) -> dict:
+        """Close the current audit log and move every rotated file out of the plugin's namespace.
+
+        server_audit renames .1 to .2, .2 to .3 and so on at every rotation, so a file
+        name is only stable until the next one. Staging under a unique name means we
+        can't upload one file and then delete another that rotated into its name.
+        """
+        mariadb = Database(private_ip, self.db_port, "root", mariadb_root_password, "mysql")
+        mariadb.execute_query("SET GLOBAL server_audit_file_rotate_now = 1;", commit=True)
+
+        os.makedirs(self.audit_log_pending_directory, exist_ok=True)
+        staged = []
+        for log in list_audit_logs(self.audit_log_directory, AUDIT_LOG_ROTATED_RE):
+            source = os.path.join(self.audit_log_directory, log["name"])
+            index = log["name"].rsplit(".", 1)[-1]
+            rotated_at = datetime.fromtimestamp(log["modified_at"]).strftime("%Y%m%d%H%M%S")
+            destination = os.path.join(
+                self.audit_log_pending_directory, f"server_audit_{rotated_at}_{index}.log"
+            )
+            # os.rename overwrites silently. Refuse rather than lose an audit log.
+            if os.path.exists(destination):
+                raise FileExistsError(f"Staged audit log already exists: {destination}")
+            os.rename(source, destination)
+            staged.append(os.path.basename(destination))
+
+        return {"staged_files": staged}
+
+    @step("Upload Audit Logs To S3")
+    def upload_audit_logs_to_s3(self, offsite: dict) -> dict:
+        import boto3
+
+        offsite_files = {}
+        failed_uploads = {}
+
+        bucket, auth, prefix = (
+            offsite["bucket"],
+            offsite["auth"],
+            offsite["path"],
+        )
+        region = auth.get("REGION")
+
+        if region:
+            s3 = boto3.client(
+                "s3",
+                aws_access_key_id=auth["ACCESS_KEY"],
+                aws_secret_access_key=auth["SECRET_KEY"],
+                region_name=region,
+            )
+        else:
+            s3 = boto3.client(
+                "s3",
+                aws_access_key_id=auth["ACCESS_KEY"],
+                aws_secret_access_key=auth["SECRET_KEY"],
+            )
+
+        tmp_folder = get_tmp_folder_path()
+        for log in list_audit_logs(self.audit_log_pending_directory, AUDIT_LOG_STAGED_RE):
+            audit_log = log["name"]
+            audit_log_path = os.path.join(self.audit_log_pending_directory, audit_log)
+            audit_log_gz_path = os.path.join(tmp_folder, f"{audit_log}.gz")
+            offsite_path = os.path.join(prefix, f"{audit_log}.gz")
+            try:
+                start, end = parse_audit_log_time_range(audit_log_path)
+                if not start:
+                    # Nothing was audited in this window. Don't bill for an empty object.
+                    os.remove(audit_log_path)
+                    continue
+
+                cmd = f"gzip -c {audit_log_path} > {audit_log_gz_path}"
+                subprocess.run(cmd, shell=True, check=True)
+                gzipped_size = os.path.getsize(audit_log_gz_path)
+                with open(audit_log_gz_path, "rb") as f:
+                    s3.upload_fileobj(f, bucket, offsite_path)
+                offsite_files[audit_log] = {
+                    "size": gzipped_size,
+                    "uncompressed_size": log["size"],
+                    "path": offsite_path,
+                    "start_timestamp": start,
+                    "end_timestamp": end,
+                }
+                # Unlike binlogs, nothing else reclaims this disk space for us
+                os.remove(audit_log_path)
+            except Exception as e:
+                failed_uploads[audit_log] = str(e)
+            finally:
+                with contextlib.suppress(Exception):
+                    os.remove(audit_log_gz_path)
+
+        return {
+            "offsite_files": offsite_files,
+            "failed_uploads": failed_uploads,
+        }
+
     def _get_current_binlog(self) -> str | None:
         index_file = Path(self.mariadb_directory) / "mysql-bin.index"
         if index_file.exists():
@@ -948,3 +1061,39 @@ def get_tmp_folder_path():
     if not os.path.exists(path):
         return "/tmp/"
     return path
+
+
+def list_audit_logs(directory: str, pattern: re.Pattern) -> list[dict]:
+    path = Path(directory)
+    if not path.exists():
+        return []
+
+    logs = []
+    for file in path.iterdir():
+        if not pattern.match(file.name):
+            continue
+        stat = file.stat()
+        logs.append({"name": file.name, "size": stat.st_size, "modified_at": stat.st_mtime})
+
+    return sorted(logs, key=lambda log: log["name"])
+
+
+def parse_audit_log_time_range(path: str) -> tuple[str | None, str | None]:
+    """Return the timestamps of the first and last record in a server_audit log.
+
+    Press shows this as the window the file covers, so it has to come from the records
+    themselves rather than the file's mtime.
+    """
+    start = end = None
+    with open(path, errors="replace") as f:
+        for line in f:
+            # Queries can contain newlines, so match the record prefix instead of
+            # assuming one record per line.
+            if not AUDIT_LOG_RECORD_RE.match(line):
+                continue
+            timestamp = datetime.strptime(line[:17], "%Y%m%d %H:%M:%S").isoformat()
+            if start is None:
+                start = timestamp
+            end = timestamp
+
+    return start, end

--- a/agent/database_server.py
+++ b/agent/database_server.py
@@ -903,13 +903,26 @@ WHERE `schema` IN (
     def stage_audit_logs(self, private_ip: str, mariadb_root_password: str) -> dict:
         """Close the current audit log and move every rotated file out of the plugin's namespace.
 
-        server_audit renames .1 to .2, .2 to .3 and so on at every rotation, so a file
-        name is only stable until the next one. Staging under a unique name means we
-        can't upload one file and then delete another that rotated into its name.
+        server_audit renames .1 to .2, .2 to .3 and so on at every rotation, so a file name
+        is only stable until the next one. Size-based rotation is switched off for the
+        duration so the only rotation is ours and the names can't move under us, then each
+        file is staged under a name nothing will reuse.
         """
         mariadb = Database(private_ip, self.db_port, "root", mariadb_root_password, "mysql")
-        mariadb.execute_query("SET GLOBAL server_audit_file_rotate_now = 1;", commit=True)
+        rotate_size = self.get_global(mariadb, "server_audit_file_rotate_size")
+        mariadb.execute_query("SET GLOBAL server_audit_file_rotate_size = 0;", commit=True)
+        try:
+            mariadb.execute_query("SET GLOBAL server_audit_file_rotate_now = 1;", commit=True)
+            staged = self.move_rotated_audit_logs_to_pending()
+        finally:
+            # Left off, the live log would grow past the disk cap until the next run
+            mariadb.execute_query(
+                f"SET GLOBAL server_audit_file_rotate_size = {int(rotate_size)};", commit=True
+            )
 
+        return {"staged_files": staged}
+
+    def move_rotated_audit_logs_to_pending(self) -> list[str]:
         os.makedirs(self.audit_log_pending_directory, exist_ok=True)
         staged = []
         for log in list_audit_logs(self.audit_log_directory, AUDIT_LOG_ROTATED_RE):
@@ -919,14 +932,22 @@ WHERE `schema` IN (
             destination = os.path.join(
                 self.audit_log_pending_directory, f"server_audit_{rotated_at}_{index}.log"
             )
-            # os.rename clobbers silently, and checking first leaves a window where an
-            # overlapping job replaces the path and we later delete a log we never
-            # uploaded. os.link refuses an existing destination atomically.
+            # os.rename would clobber an existing destination silently; os.link refuses it
             os.link(source, destination)
-            os.unlink(source)
+            # Only drop the source if it is still the file we just linked. A rotation here
+            # would have rebound the name to a log we never staged.
+            if os.stat(source).st_ino == os.stat(destination).st_ino:
+                os.unlink(source)
             staged.append(os.path.basename(destination))
 
-        return {"staged_files": staged}
+        return staged
+
+    @staticmethod
+    def get_global(mariadb: Database, variable: str) -> int:
+        success, output = mariadb.execute_query(f"SELECT @@GLOBAL.{variable} AS value;")
+        if not success:
+            raise Exception(f"Failed to read {variable}: {output}")
+        return output[0]["output"]["data"][0][0]
 
     @step("Upload Audit Logs To S3")
     def upload_audit_logs_to_s3(self, offsite: dict) -> dict:

--- a/agent/database_server.py
+++ b/agent/database_server.py
@@ -920,21 +920,12 @@ WHERE `schema` IN (
         """Rotate the audit log and move the rotated files out of the plugin's namespace.
 
         server_audit renames .1 to .2 and so on at every rotation, so names are only stable
-        between them. Size rotation is off for the duration to keep ours the only one.
+        between them. audit_log_lock keeps ours the only rotation for the duration.
         """
         mariadb = Database(private_ip, self.db_port, "root", mariadb_root_password, "mysql")
-        rotate_size = self.get_global(mariadb, "server_audit_file_rotate_size")
-        mariadb.execute_query("SET GLOBAL server_audit_file_rotate_size = 0;", commit=True)
-        try:
-            mariadb.execute_query("SET GLOBAL server_audit_file_rotate_now = 1;", commit=True)
-            staged = self.move_rotated_audit_logs_to_pending()
-        finally:
-            # Left off, the live log would grow past the disk cap until the next run
-            mariadb.execute_query(
-                f"SET GLOBAL server_audit_file_rotate_size = {int(rotate_size)};", commit=True
-            )
+        mariadb.execute_query("SET GLOBAL server_audit_file_rotate_now = 1;", commit=True)
 
-        return {"staged_files": staged}
+        return {"staged_files": self.move_rotated_audit_logs_to_pending()}
 
     def move_rotated_audit_logs_to_pending(self) -> list[str]:
         os.makedirs(self.audit_log_pending_directory, exist_ok=True)
@@ -954,13 +945,6 @@ WHERE `schema` IN (
             staged.append(os.path.basename(destination))
 
         return staged
-
-    @staticmethod
-    def get_global(mariadb: Database, variable: str) -> int:
-        success, output = mariadb.execute_query(f"SELECT @@GLOBAL.{variable} AS value;")
-        if not success:
-            raise Exception(f"Failed to read {variable}: {output}")
-        return output[0]["output"]["data"][0][0]
 
     @step("Upload Audit Logs To S3")
     def upload_audit_logs_to_s3(self, offsite: dict) -> dict:

--- a/agent/database_server.py
+++ b/agent/database_server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import fcntl
 import json
 import os
 import re
@@ -896,17 +897,30 @@ WHERE `schema` IN (
 
     @job("Upload Audit Logs To S3", priority="low")
     def upload_audit_logs_to_s3_job(self, private_ip: str, mariadb_root_password: str, offsite: dict) -> dict:
-        self.stage_audit_logs(private_ip, mariadb_root_password)
-        return self.upload_audit_logs_to_s3(offsite)
+        with self.audit_log_lock():
+            self.stage_audit_logs(private_ip, mariadb_root_password)
+            return self.upload_audit_logs_to_s3(offsite)
+
+    @contextlib.contextmanager
+    def audit_log_lock(self):
+        """Refuse overlapping runs, which would rotate and unlink under each other."""
+        os.makedirs(self.audit_log_pending_directory, exist_ok=True)
+        with open(os.path.join(self.audit_log_pending_directory, ".lock"), "w") as lock:
+            try:
+                fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError as e:
+                raise Exception("Another audit log upload is already running on this server") from e
+            try:
+                yield
+            finally:
+                fcntl.flock(lock, fcntl.LOCK_UN)
 
     @step("Rotate Audit Log")
     def stage_audit_logs(self, private_ip: str, mariadb_root_password: str) -> dict:
-        """Close the current audit log and move every rotated file out of the plugin's namespace.
+        """Rotate the audit log and move the rotated files out of the plugin's namespace.
 
-        server_audit renames .1 to .2, .2 to .3 and so on at every rotation, so a file name
-        is only stable until the next one. Size-based rotation is switched off for the
-        duration so the only rotation is ours and the names can't move under us, then each
-        file is staged under a name nothing will reuse.
+        server_audit renames .1 to .2 and so on at every rotation, so names are only stable
+        between them. Size rotation is off for the duration to keep ours the only one.
         """
         mariadb = Database(private_ip, self.db_port, "root", mariadb_root_password, "mysql")
         rotate_size = self.get_global(mariadb, "server_audit_file_rotate_size")
@@ -934,8 +948,7 @@ WHERE `schema` IN (
             )
             # os.rename would clobber an existing destination silently; os.link refuses it
             os.link(source, destination)
-            # Only drop the source if it is still the file we just linked. A rotation here
-            # would have rebound the name to a log we never staged.
+            # Nothing can rotate here, but unlinking a rebound name loses a log for good
             if os.stat(source).st_ino == os.stat(destination).st_ino:
                 os.unlink(source)
             staged.append(os.path.basename(destination))

--- a/agent/database_server.py
+++ b/agent/database_server.py
@@ -920,12 +920,28 @@ WHERE `schema` IN (
         """Rotate the audit log and move the rotated files out of the plugin's namespace.
 
         server_audit renames .1 to .2 and so on at every rotation, so names are only stable
-        between them. audit_log_lock keeps ours the only rotation for the duration.
+        between them. Rotations are frozen while the files are moved, and audit_log_lock
+        keeps a second run from rotating too.
         """
         mariadb = Database(private_ip, self.db_port, "root", mariadb_root_password, "mysql")
+        rotations = self.get_global(mariadb, "server_audit_file_rotations")
         mariadb.execute_query("SET GLOBAL server_audit_file_rotate_now = 1;", commit=True)
+        # 0 means the plugin stops rotating, so the names can't move while we read them
+        mariadb.execute_query("SET GLOBAL server_audit_file_rotations = 0;", commit=True)
+        try:
+            staged = self.move_rotated_audit_logs_to_pending()
+        finally:
+            # Left at 0 the live log never rotates and grows past the disk cap
+            mariadb.execute_query(f"SET GLOBAL server_audit_file_rotations = {int(rotations)};", commit=True)
 
-        return {"staged_files": self.move_rotated_audit_logs_to_pending()}
+        return {"staged_files": staged}
+
+    @staticmethod
+    def get_global(mariadb: Database, variable: str) -> int:
+        success, output = mariadb.execute_query(f"SELECT @@GLOBAL.{variable};")
+        if not success:
+            raise Exception(f"Failed to read {variable}: {output}")
+        return output[0]["output"]["data"][0][0]
 
     def move_rotated_audit_logs_to_pending(self) -> list[str]:
         os.makedirs(self.audit_log_pending_directory, exist_ok=True)

--- a/agent/tests/test_database_server.py
+++ b/agent/tests/test_database_server.py
@@ -163,3 +163,28 @@ class TestStageAuditLogs(unittest.TestCase):
             (Path(self.server.audit_log_pending_directory) / staged).read_text(),
             RECORD.format(second="01"),
         )
+
+
+class TestAuditLogLock(unittest.TestCase):
+    def setUp(self):
+        self.directory = TemporaryDirectory()
+        self.server = DatabaseServer.__new__(DatabaseServer)
+        self.server.audit_log_pending_directory = os.path.join(self.directory.name, "audit_pending")
+
+    def tearDown(self):
+        self.directory.cleanup()
+
+    def acquire(self):
+        with self.server.audit_log_lock():
+            pass
+
+    def test_a_second_run_is_refused_while_the_first_holds_the_lock(self):
+        # Overlapping runs rotate and unlink under each other, which loses audit logs
+        with self.server.audit_log_lock():
+            self.assertRaisesRegex(Exception, "already running", self.acquire)
+
+    def test_the_lock_is_released_when_a_run_fails(self):
+        with self.assertRaises(OSError), self.server.audit_log_lock():
+            raise OSError
+
+        self.acquire()

--- a/agent/tests/test_database_server.py
+++ b/agent/tests/test_database_server.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from agent.database_server import (
+    AUDIT_LOG_ROTATED_RE,
+    AUDIT_LOG_STAGED_RE,
+    DatabaseServer,
+    list_audit_logs,
+    parse_audit_log_time_range,
+)
+
+RECORD = "20250811 12:00:{second},dbserver,root,localhost,42,1337,QUERY,mydb,'select 1',0\n"
+
+
+def write(path: Path, content: str) -> str:
+    path.write_text(content)
+    return str(path)
+
+
+class TestParseAuditLogTimeRange(unittest.TestCase):
+    def setUp(self):
+        self.directory = TemporaryDirectory()
+        self.path = Path(self.directory.name)
+
+    def tearDown(self):
+        self.directory.cleanup()
+
+    def test_returns_first_and_last_record_timestamps(self):
+        log = write(
+            self.path / "audit.log",
+            RECORD.format(second="01") + RECORD.format(second="02") + RECORD.format(second="03"),
+        )
+
+        self.assertEqual(
+            parse_audit_log_time_range(log),
+            ("2025-08-11T12:00:01", "2025-08-11T12:00:03"),
+        )
+
+    def test_ignores_continuation_lines_of_a_query_containing_newlines(self):
+        log = write(
+            self.path / "audit.log",
+            RECORD.format(second="01")
+            + "20250811 12:00:05,dbserver,root,localhost,42,1338,QUERY,mydb,'select\n"
+            + "1 from t',0\n",
+        )
+
+        # The trailing "1 from t',0" line is part of the previous record, so the end of
+        # the range is 12:00:05 and not something parsed out of that fragment.
+        self.assertEqual(
+            parse_audit_log_time_range(log),
+            ("2025-08-11T12:00:01", "2025-08-11T12:00:05"),
+        )
+
+    def test_returns_none_for_an_empty_file(self):
+        self.assertEqual(parse_audit_log_time_range(write(self.path / "audit.log", "")), (None, None))
+
+    def test_returns_none_when_no_line_looks_like_a_record(self):
+        log = write(self.path / "audit.log", "not an audit record\nnor is this\n")
+
+        self.assertEqual(parse_audit_log_time_range(log), (None, None))
+
+
+class TestListAuditLogs(unittest.TestCase):
+    def setUp(self):
+        self.directory = TemporaryDirectory()
+        self.path = Path(self.directory.name)
+
+    def tearDown(self):
+        self.directory.cleanup()
+
+    def test_lists_only_rotated_logs_sorted_by_name(self):
+        for name in ["server_audit.log", "server_audit.log.2", "server_audit.log.1", "mysql-error.log"]:
+            write(self.path / name, "")
+
+        # The live server_audit.log is excluded: the plugin still holds it open.
+        self.assertEqual(
+            [log["name"] for log in list_audit_logs(str(self.path), AUDIT_LOG_ROTATED_RE)],
+            ["server_audit.log.1", "server_audit.log.2"],
+        )
+
+    def test_returns_empty_list_when_directory_is_missing(self):
+        self.assertEqual(list_audit_logs(str(self.path / "nope"), AUDIT_LOG_ROTATED_RE), [])
+
+
+class TestStageAuditLogs(unittest.TestCase):
+    def setUp(self):
+        self.directory = TemporaryDirectory()
+        self.server = DatabaseServer.__new__(DatabaseServer)
+        self.server.audit_log_directory = self.directory.name
+        self.server.audit_log_pending_directory = os.path.join(self.directory.name, "audit_pending")
+
+    def tearDown(self):
+        self.directory.cleanup()
+
+    def stage(self):
+        # Only the MariaDB connection is mocked; the file moves are real.
+        with patch("agent.database_server.Database"), patch.object(DatabaseServer, "db_port", 3306):
+            return DatabaseServer.stage_audit_logs.__wrapped__(self.server, "127.0.0.1", "password")
+
+    def test_moves_rotated_logs_out_of_the_plugin_namespace(self):
+        for name in ["server_audit.log", "server_audit.log.1", "server_audit.log.2"]:
+            write(Path(self.directory.name) / name, RECORD.format(second="01"))
+
+        staged = self.stage()["staged_files"]
+
+        self.assertEqual(len(staged), 2)
+        for name in staged:
+            self.assertRegex(name, AUDIT_LOG_STAGED_RE)
+        # Nothing rotated is left behind for the next rotation to renumber
+        self.assertEqual(list_audit_logs(self.directory.name, AUDIT_LOG_ROTATED_RE), [])
+        # The live log the plugin is writing to is untouched
+        self.assertTrue((Path(self.directory.name) / "server_audit.log").exists())
+
+    def test_refuses_to_overwrite_an_already_staged_log(self):
+        source = Path(self.directory.name) / "server_audit.log.1"
+        write(source, RECORD.format(second="01"))
+        os.makedirs(self.server.audit_log_pending_directory)
+
+        [staged] = self.stage()["staged_files"]
+        write(source, RECORD.format(second="02"))
+        os.utime(source, (0, os.stat(Path(self.server.audit_log_pending_directory) / staged).st_mtime))
+
+        with self.assertRaises(FileExistsError):
+            self.stage()
+
+        # os.rename would have clobbered the earlier log silently; it is still intact
+        self.assertTrue(source.exists())
+        self.assertEqual(
+            (Path(self.server.audit_log_pending_directory) / staged).read_text(),
+            RECORD.format(second="01"),
+        )

--- a/agent/tests/test_database_server.py
+++ b/agent/tests/test_database_server.py
@@ -99,8 +99,36 @@ class TestStageAuditLogs(unittest.TestCase):
 
     def stage(self):
         # Only the MariaDB connection is mocked; the file moves are real.
-        with patch("agent.database_server.Database"), patch.object(DatabaseServer, "db_port", 3306):
+        with patch("agent.database_server.Database") as db, patch.object(DatabaseServer, "db_port", 3306):
+            self.queries = db.return_value.execute_query
+            self.queries.return_value = (True, [{"output": {"data": [[9]]}}])
             return DatabaseServer.stage_audit_logs.__wrapped__(self.server, "127.0.0.1", "password")
+
+    def executed(self):
+        return [call.args[0] for call in self.queries.call_args_list]
+
+    def test_rotations_are_frozen_while_the_files_are_moved_and_restored_after(self):
+        # A rotation midway renumbers every file, and left at 0 the log never rotates again
+        write(Path(self.directory.name) / "server_audit.log.1", RECORD.format(second="01"))
+
+        self.stage()
+
+        self.assertEqual(
+            self.executed()[1:],
+            [
+                "SET GLOBAL server_audit_file_rotate_now = 1;",
+                "SET GLOBAL server_audit_file_rotations = 0;",
+                "SET GLOBAL server_audit_file_rotations = 9;",
+            ],
+        )
+
+    def test_rotations_are_restored_even_when_staging_blows_up(self):
+        write(Path(self.directory.name) / "server_audit.log.1", RECORD.format(second="01"))
+
+        with patch.object(DatabaseServer, "move_rotated_audit_logs_to_pending", side_effect=OSError):
+            self.assertRaises(OSError, self.stage)
+
+        self.assertEqual(self.executed()[-1], "SET GLOBAL server_audit_file_rotations = 9;")
 
     def test_moves_rotated_logs_out_of_the_plugin_namespace(self):
         for name in ["server_audit.log", "server_audit.log.1", "server_audit.log.2"]:

--- a/agent/tests/test_database_server.py
+++ b/agent/tests/test_database_server.py
@@ -99,37 +99,8 @@ class TestStageAuditLogs(unittest.TestCase):
 
     def stage(self):
         # Only the MariaDB connection is mocked; the file moves are real.
-        with patch("agent.database_server.Database") as Db, patch.object(DatabaseServer, "db_port", 3306):
-            self.queries = Db.return_value.execute_query
-            self.queries.return_value = (True, [{"output": {"data": [[1073741824]]}}])
+        with patch("agent.database_server.Database"), patch.object(DatabaseServer, "db_port", 3306):
             return DatabaseServer.stage_audit_logs.__wrapped__(self.server, "127.0.0.1", "password")
-
-    def executed(self):
-        return [call.args[0] for call in self.queries.call_args_list]
-
-    def test_size_rotation_is_off_only_while_the_files_are_being_moved(self):
-        # A rotation midway renumbers every file, so ours must be the only one that can
-        # happen while we are moving them. It has to go back on or the log outgrows the cap.
-        write(Path(self.directory.name) / "server_audit.log.1", RECORD.format(second="01"))
-
-        self.stage()
-
-        self.assertEqual(
-            self.executed()[1:],
-            [
-                "SET GLOBAL server_audit_file_rotate_size = 0;",
-                "SET GLOBAL server_audit_file_rotate_now = 1;",
-                "SET GLOBAL server_audit_file_rotate_size = 1073741824;",
-            ],
-        )
-
-    def test_size_rotation_is_restored_even_when_staging_blows_up(self):
-        write(Path(self.directory.name) / "server_audit.log.1", RECORD.format(second="01"))
-
-        with patch.object(DatabaseServer, "move_rotated_audit_logs_to_pending", side_effect=OSError):
-            self.assertRaises(OSError, self.stage)
-
-        self.assertEqual(self.executed()[-1], "SET GLOBAL server_audit_file_rotate_size = 1073741824;")
 
     def test_moves_rotated_logs_out_of_the_plugin_namespace(self):
         for name in ["server_audit.log", "server_audit.log.1", "server_audit.log.2"]:

--- a/agent/tests/test_database_server.py
+++ b/agent/tests/test_database_server.py
@@ -99,8 +99,37 @@ class TestStageAuditLogs(unittest.TestCase):
 
     def stage(self):
         # Only the MariaDB connection is mocked; the file moves are real.
-        with patch("agent.database_server.Database"), patch.object(DatabaseServer, "db_port", 3306):
+        with patch("agent.database_server.Database") as Db, patch.object(DatabaseServer, "db_port", 3306):
+            self.queries = Db.return_value.execute_query
+            self.queries.return_value = (True, [{"output": {"data": [[1073741824]]}}])
             return DatabaseServer.stage_audit_logs.__wrapped__(self.server, "127.0.0.1", "password")
+
+    def executed(self):
+        return [call.args[0] for call in self.queries.call_args_list]
+
+    def test_size_rotation_is_off_only_while_the_files_are_being_moved(self):
+        # A rotation midway renumbers every file, so ours must be the only one that can
+        # happen while we are moving them. It has to go back on or the log outgrows the cap.
+        write(Path(self.directory.name) / "server_audit.log.1", RECORD.format(second="01"))
+
+        self.stage()
+
+        self.assertEqual(
+            self.executed()[1:],
+            [
+                "SET GLOBAL server_audit_file_rotate_size = 0;",
+                "SET GLOBAL server_audit_file_rotate_now = 1;",
+                "SET GLOBAL server_audit_file_rotate_size = 1073741824;",
+            ],
+        )
+
+    def test_size_rotation_is_restored_even_when_staging_blows_up(self):
+        write(Path(self.directory.name) / "server_audit.log.1", RECORD.format(second="01"))
+
+        with patch.object(DatabaseServer, "move_rotated_audit_logs_to_pending", side_effect=OSError):
+            self.assertRaises(OSError, self.stage)
+
+        self.assertEqual(self.executed()[-1], "SET GLOBAL server_audit_file_rotate_size = 1073741824;")
 
     def test_moves_rotated_logs_out_of_the_plugin_namespace(self):
         for name in ["server_audit.log", "server_audit.log.1", "server_audit.log.2"]:

--- a/agent/web.py
+++ b/agent/web.py
@@ -1441,6 +1441,18 @@ def upload_binlogs_to_s3():
     return {"job": job}
 
 
+@application.route("/database/audit-logs/list", methods=["GET"])
+def get_audit_logs():
+    return jsonify(DatabaseServer().get_audit_logs())
+
+
+@application.route("/database/audit-logs/upload", methods=["POST"])
+def upload_audit_logs_to_s3():
+    data = request.json
+    job = DatabaseServer().upload_audit_logs_to_s3_job(**data)
+    return {"job": job}
+
+
 @application.route("/database/binlogs/indexer/add", methods=["POST"])
 def add_binlogs_to_indexer():
     data = request.json


### PR DESCRIPTION
Adds `/database/audit-logs/list` and `/database/audit-logs/upload`.

The upload job rotates the `server_audit` log, reads the first and last record to get the window each file covers, uploads it to S3 and deletes it from disk. Press stores the window so the dashboard can list the archives.

Rotated files are moved into `audit_pending` under a unique name before upload — `server_audit` shifts `.1` to `.2` at every rotation, so a name observed at listing time isn't stable.

Needs the matching Press change, which creates `/var/log/mysql` and configures the plugin.