### PR TITLE
feat(bench): show custom page for werkzeug internal server error

### DIFF
--- a/agent/pages/bad_gateway.html
+++ b/agent/pages/bad_gateway.html
@@ -135,7 +135,7 @@
         <p class="message">
           Your bench appears to be down.
           <a
-            href="https://docs.frappe.io/cloud/performance-error-debugging#502-bad-gateway"
+            href="https://docs.frappe.io/cloud/site/common-issues/502-bad-gateway"
             style="
               display: inline-block;
               margin-top: 10px;

--- a/agent/pages/gateway_timeout.html
+++ b/agent/pages/gateway_timeout.html
@@ -135,7 +135,7 @@
         <p class="message">
           Your site appears to be running slow.
           <a
-            href="https://docs.frappe.io/cloud/performance-error-debugging#site-slow-504-gateway-timeout"
+            href="https://docs.frappe.io/cloud/site/common-issues/site-slow-504-gateway-timeout"
             style="
               display: inline-block;
               margin-top: 10px;

--- a/agent/pages/internal_server_error.html
+++ b/agent/pages/internal_server_error.html
@@ -135,7 +135,7 @@
         <p class="message">
           There seems to be an error in your application.
           <a
-            href="https://docs.frappe.io/cloud/performance-error-debugging#500-internal-server-error"
+            href="https://docs.frappe.io/cloud/site/common-issues/500-internal-server-error"
             style="
               display: inline-block;
               margin-top: 10px;

--- a/agent/templates/bench/nginx.conf.jinja2
+++ b/agent/templates/bench/nginx.conf.jinja2
@@ -16,6 +16,15 @@ map $host $site_name_{{ bench_name_slug }} {
 	default $host;
 }
 
+# when the app breaks before frappe can render its own error page, gunicorn/werkzeug
+# send their bare "Internal Server Error" html. swap it for our page.
+# done with sub_filter and not `error_page 500` because interception throws away the
+# response body, which would kill frappe's own error pages and api tracebacks
+map $upstream_status $internal_server_error_page_{{ bench_name_slug }} {
+	500     '<style>html,body{margin:0;height:100%}iframe{border:0;width:100%;height:100%}</style><iframe src="/internal_server_error.html"></iframe><div hidden>';
+	default '<h1>Internal Server Error</h1>';
+}
+
 {% if cors_origins %}
 map "$host:$http_origin" $cors_origin_{{ bench_name_slug }} {
 	default "";
@@ -153,7 +162,13 @@ server {
 		proxy_read_timeout {{ http_timeout }};
 		proxy_redirect off;
 
+		sub_filter '<h1>Internal Server Error</h1>' $internal_server_error_page_{{ bench_name_slug }};
+
 		proxy_pass  http://{{ bench_name }}-web-server;
+	}
+
+	location = /internal_server_error.html {
+		root {{ error_pages_directory }};
 	}
 
 	proxy_intercept_errors on;
@@ -314,7 +329,13 @@ server {
 		proxy_read_timeout {{ http_timeout }};
 		proxy_redirect off;
 
+		sub_filter '<h1>Internal Server Error</h1>' $internal_server_error_page_{{ bench_name_slug }};
+
 		proxy_pass  http://{{ bench_name }}-web-server;
+	}
+
+	location = /internal_server_error.html {
+		root {{ error_pages_directory }};
 	}
 
 	# optimizations

--- a/agent/templates/bench/nginx.conf.jinja2
+++ b/agent/templates/bench/nginx.conf.jinja2
@@ -16,13 +16,21 @@ map $host $site_name_{{ bench_name_slug }} {
 	default $host;
 }
 
-# when the app breaks before frappe can render its own error page, gunicorn/werkzeug
-# send their bare "Internal Server Error" html. swap it for our page.
+# when frappe cannot report the error itself, the bare "Internal Server Error" html
+# comes from gunicorn (exception escaped frappe entirely, e.g. a broken app that also
+# breaks the rendering of frappe's own error page) or from werkzeug (HTTPException
+# raised inside frappe). swap either for our page. the two write the same heading
+# differently, hence the two maps.
 # done with sub_filter and not `error_page 500` because interception throws away the
 # response body, which would kill frappe's own error pages and api tracebacks
 map $upstream_status $internal_server_error_page_{{ bench_name_slug }} {
 	500     '<style>html,body{margin:0;height:100%}iframe{border:0;width:100%;height:100%}</style><iframe src="/internal_server_error.html"></iframe><div hidden>';
 	default '<h1>Internal Server Error</h1>';
+}
+
+map $upstream_status $gunicorn_internal_server_error_page_{{ bench_name_slug }} {
+	500     '<style>html,body{margin:0;height:100%}iframe{border:0;width:100%;height:100%}</style><iframe src="/internal_server_error.html"></iframe><div hidden>';
+	default '<h1><p>Internal Server Error</p></h1>';
 }
 
 {% if cors_origins %}
@@ -163,6 +171,7 @@ server {
 		proxy_redirect off;
 
 		sub_filter '<h1>Internal Server Error</h1>' $internal_server_error_page_{{ bench_name_slug }};
+		sub_filter '<h1><p>Internal Server Error</p></h1>' $gunicorn_internal_server_error_page_{{ bench_name_slug }};
 
 		proxy_pass  http://{{ bench_name }}-web-server;
 	}
@@ -330,6 +339,7 @@ server {
 		proxy_redirect off;
 
 		sub_filter '<h1>Internal Server Error</h1>' $internal_server_error_page_{{ bench_name_slug }};
+		sub_filter '<h1><p>Internal Server Error</p></h1>' $gunicorn_internal_server_error_page_{{ bench_name_slug }};
 
 		proxy_pass  http://{{ bench_name }}-web-server;
 	}


### PR DESCRIPTION
When an app breaks in a way frappe cannot report itself, the client gets gunicorn's or werkzeug's bare `Internal Server Error` html. This swaps that page for the Frappe Cloud one, without touching any response frappe itself produced.

### Why not `error_page 500`

That was tried before in 1a15398 and rolled back in cf5f07c. `proxy_intercept_errors` discards the upstream body *before* any `if` in the error page location runs, so frappe's own error pages and API tracebacks were replaced by nginx's bare 500 page. Reproduced on nginx 1.30:

| upstream 500 | `error_page 500` + guards | this PR |
| --- | --- | --- |
| gunicorn / werkzeug bare page | custom page ✅ | custom page ✅ |
| frappe html error page | nginx bare 500 ❌ | passes through ✅ |
| frappe json `{"exception": "Traceback..."}` | nginx bare 500 html ❌ | passes through byte-identical ✅ |

`sub_filter` rewrites the body instead of intercepting, so the match is exact: only the two bare headings are replaced, and only when `$upstream_status` is 500. Everything else is a no-op.

This lives in the bench nginx config, not the proxy, because the bench nginx gzips text/html — the proxy only ever sees a compressed body, where `sub_filter` cannot match.

Status code (500) and the request URL are preserved; the page renders in a full-viewport iframe and the remaining markup is swallowed by a trailing hidden div.

### The two bare pages

Both arrive on a live socket — the worker is up and answering, which is why these are 500 and not 502 (nothing listening at all is a 502, and `bad_gateway.html` already covers that through `error_page`).

- **gunicorn**, `<h1><p>Internal Server Error</p></h1>` — the exception escaped frappe entirely. A syntax error in an installed app raises once inside frappe's `try`, then raises *again* while `handle_exception` renders frappe's own error page (`ErrorPage` → `template_page.set_template_path` → `frappe.get_app_path` re-imports the broken app). The second one is outside every handler and is not an `HTTPException`, so it lands on gunicorn.
- **werkzeug**, `<h1>Internal Server Error</h1>` — an `HTTPException` with code 500 reached `@Request.application`, which renders werkzeug's generic page. frappe never raises one itself (no `InternalServerError` / `abort(500)` anywhere in `frappe/`), so this is app code calling `abort(500)`, or an `HTTPException` raised outside frappe's `try`.

A plain exception inside frappe's `try` is caught by `except Exception` and gets frappe's own page or a JSON traceback — untouched by this change.

### Testing

On a bench server running this branch, against a site with `frappe`, `payments`, `email_delivery_service` installed.

**1. Real broken app (the gunicorn page).** Appended `def deliberately_broken(:` to `email_delivery_service/email_delivery_service/__init__.py` and restarted the web process:

```
HTTP/1.1 500 Internal Server Error

<html>
  <head>
    <title>Internal Server Error</title>
  </head>
  <body>
    <style>html,body{margin:0;height:100%}iframe{...}</style><iframe src="/internal_server_error.html"></iframe><div hidden>
  </body>
</html>
```

`web.error.log` confirms the chain: `SyntaxError` → `handle_exception` → `ErrorPage` → `get_app_path` → same `SyntaxError` → `[ERROR] Error handling request /`. No worker exit until the restart afterwards.

**2. Werkzeug page.** Patched `frappe/app.py` to `raise InternalServerError()` from the `finally` block of `application()` for one magic path, so it escapes frappe's handler the way an `abort(500)` would → `500` with the custom page injected.

**3. Frappe's own errors pass through.** Same patch, second magic path raising a plain `Exception` inside the `try`:

- browser request → frappe's own "Server Error" page, unmodified
- `Accept: application/json` → `500` with `{"exception": "Exception: deliberate test error", "exc": "[\"Traceback (most recent call last):\\n File \\\"apps/frappe/frappe/app.py\\\"...\"]"}`, byte-identical

**4. No regression on normal traffic.** Site home page (136KB html) and `/api/method/frappe.ping` both 200 with the filter active.

**5. Response matrix through the generated config.** Before the live tests, the bench upstream was pointed at a stub emitting each response type — werkzeug page, frappe html 500 with `X-Page-Name`, frappe json 500, normal 200 — confirming the swap fires only on the first.

All patched files were restored from backups afterwards and the site verified back at 200.

Note: this needs nginx built `--with-http_sub_module` (present on the servers checked — `nginx -t` fails loudly on `sub_filter` otherwise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
