### PR TITLE
feat(jobs): Add a site-scoped backup jobs endpoint

### DIFF
--- a/agent/backup_log.py
+++ b/agent/backup_log.py
@@ -40,30 +40,47 @@ class InvalidRange(Exception):
     """The caller asked for a range that cannot be served."""
 
 
-def get_backup_jobs(site: str, start: str, end: str) -> list[dict]:
+def get_backup_jobs(site: str, start: str, end: str) -> dict:
     """Every Backup Site job this server ran for one site, newest first."""
     start_at, end_at = parse_range(start, end)
 
-    jobs = (
+    query = (
         JobModel.select()
         .where(
             (JobModel.name == JOB_NAME)
-            # A LIKE narrows the scan; site_of below is what actually decides
-            & (JobModel.data.contains(site))
+            & matches_site(site)
             & (JobModel.start >= start_at)
             & (JobModel.start < end_at)
         )
         .order_by(JobModel.id.desc())
-        .limit(MAX_JOBS)
+        # One over the cap, so a full page can be told apart from an exact fit
+        .limit(MAX_JOBS + 1)
     )
 
-    jobs = list(jobs)
+    jobs = list(query)
+    truncated = len(jobs) > MAX_JOBS
+    jobs = jobs[:MAX_JOBS]
+
     steps = steps_of(jobs)
-    return [
-        summarise(job, steps.get(job.id, []))
-        for job in jobs
-        if site_of(load_json(job.data), steps.get(job.id, [])) == site
-    ]
+    return {
+        "jobs": [
+            summarise(job, steps.get(job.id, []))
+            for job in jobs
+            # site_of still decides, in case a LIKE wildcard widened the match
+            if site_of(load_json(job.data), steps.get(job.id, [])) == site
+        ],
+        # Says so rather than quietly dropping the oldest days in the range
+        "truncated": truncated,
+    }
+
+
+def matches_site(site: str):
+    """Match the site's own backup paths.
+
+    Anchored on the separators around the name, so a site whose name merely contains
+    this one cannot match and eat the row limit before the exact filter runs.
+    """
+    return JobModel.data.contains(f"/{site}/private/backups/") | JobModel.data.contains(f"://{site}/backups/")
 
 
 def parse_range(start: str, end: str) -> tuple[datetime, datetime]:

--- a/agent/backup_log.py
+++ b/agent/backup_log.py
@@ -1,0 +1,207 @@
+"""Backup Site jobs read back out of the agent's job database.
+
+Press keeps its own Site Backup records, but a site that has moved between servers
+leaves its older jobs behind on the server it ran them on. This is how those are
+read back, per site and bounded to a date range.
+
+The parsing mirrors frappe/fc-scripts/create_backup_log.py, which does the same
+thing by opening jobs.sqlite3 directly.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timedelta
+
+from agent.job import JobModel, StepModel
+
+JOB_NAME = "Backup Site"
+UPLOAD_STEP = "Upload Site Backup to S3"
+
+# An audit asks about a year at a time, and the cap keeps one call from walking the
+# whole job database
+MAX_RANGE_DAYS = 366
+MAX_JOBS = 2000
+
+ARTIFACTS = ("database", "public", "private", "site_config")
+
+# Backups live at <bench>/sites/<site>/private/backups/, and their url is the site itself
+SITE_FROM_PATH = re.compile(r"(?:/sites/|^\./)([^/]+)/private/backups/")
+SITE_FROM_URL = re.compile(r"^https?://([^/]+)/")
+
+# "FileNotFoundError: [Errno 2] ...", "subprocess.CalledProcessError: ..."
+EXCEPTION_LINE = re.compile(r"^(?:[A-Za-z_][\w.]*\.)?[A-Z]\w*(?:Error|Exception|Exit|Interrupt|Warning)\b.*")
+
+TRACEBACK_NOISE = ('File "', "Traceback", "^", "~", "During handling", "The above exception")
+
+
+class InvalidRange(Exception):
+    """The caller asked for a range that cannot be served."""
+
+
+def get_backup_jobs(site: str, start: str, end: str) -> list[dict]:
+    """Every Backup Site job this server ran for one site, newest first."""
+    start_at, end_at = parse_range(start, end)
+
+    jobs = (
+        JobModel.select()
+        .where(
+            (JobModel.name == JOB_NAME)
+            # A LIKE narrows the scan; site_of below is what actually decides
+            & (JobModel.data.contains(site))
+            & (JobModel.start >= start_at)
+            & (JobModel.start < end_at)
+        )
+        .order_by(JobModel.id.desc())
+        .limit(MAX_JOBS)
+    )
+
+    jobs = list(jobs)
+    steps = steps_of(jobs)
+    return [
+        summarise(job, steps.get(job.id, []))
+        for job in jobs
+        if site_of(load_json(job.data), steps.get(job.id, [])) == site
+    ]
+
+
+def parse_range(start: str, end: str) -> tuple[datetime, datetime]:
+    """Both ends as datetimes, with end pushed to the following midnight so it counts."""
+    try:
+        start_at = datetime.strptime(start, "%Y-%m-%d")
+        end_at = datetime.strptime(end, "%Y-%m-%d")
+    except (TypeError, ValueError):
+        raise InvalidRange("start and end must be dates formatted YYYY-MM-DD")
+
+    if start_at > end_at:
+        raise InvalidRange("start must be on or before end")
+    if (end_at - start_at).days >= MAX_RANGE_DAYS:
+        raise InvalidRange(f"range must be {MAX_RANGE_DAYS} days or less")
+
+    return start_at, end_at + timedelta(days=1)
+
+
+def steps_of(jobs: list[JobModel]) -> dict[int, list[tuple]]:
+    if not jobs:
+        return {}
+
+    steps: dict[int, list[tuple]] = {}
+    query = StepModel.select(StepModel.job, StepModel.name, StepModel.status, StepModel.data).where(
+        StepModel.job << [job.id for job in jobs]
+    )
+    for step in query.order_by(StepModel.id):
+        steps.setdefault(step.job_id, []).append((step.name, step.status, load_json(step.data)))
+    return steps
+
+
+def summarise(job: JobModel, steps: list[tuple]) -> dict:
+    data = load_json(job.data)
+    backups = data.get("backups") if isinstance(data, dict) else None
+
+    return {
+        "id": job.id,
+        "agent_job_id": job.agent_job_id,
+        "status": job.status,
+        "type": backup_type(job.status, data, steps),
+        "start": str(job.start) if job.start else None,
+        "end": str(job.end) if job.end else None,
+        "duration": str(job.duration) if job.duration else None,
+        "sizes": {artifact: size_of(backups, artifact) for artifact in ARTIFACTS},
+        # Only the one interpreted line, never the raw traceback
+        "failure_reason": failure_reason(data, steps) if job.status != "Success" else "",
+    }
+
+
+def site_of(data: dict | None, steps: list[tuple]) -> str | None:
+    """The site a job ran for, read off its backup paths.
+
+    Deliberately not read from the bench command: that is caller-supplied text, and a
+    path under the site's own backup directory is the agent's own record of the run.
+    """
+    backups = data.get("backups") if isinstance(data, dict) else None
+    if not isinstance(backups, dict):
+        return None
+
+    for entry in backups.values():
+        if not isinstance(entry, dict):
+            continue
+        match = SITE_FROM_PATH.search(entry.get("path") or "")
+        if match:
+            return match.group(1)
+        match = SITE_FROM_URL.match(entry.get("url") or "")
+        if match:
+            return match.group(1)
+    return None
+
+
+def backup_type(status: str, data: dict | None, steps: list[tuple]) -> str:
+    if status != "Success":
+        return ""
+    if isinstance(data, dict) and data.get("offsite"):
+        return "offsite"
+    for step_name, step_status, _ in steps:
+        if step_name == UPLOAD_STEP and step_status == "Success":
+            return "offsite"
+    return "onsite"
+
+
+def size_of(backups: dict | None, artifact: str) -> int:
+    entry = (backups or {}).get(artifact)
+    if isinstance(entry, dict) and isinstance(entry.get("size"), int):
+        return entry["size"]
+    return 0
+
+
+def failure_reason(data: dict | None, steps: list[tuple]) -> str:
+    """Why a backup failed, preferring the innermost python exception.
+
+    The step traceback is usually the agent-side CalledProcessError wrapper, while the
+    real cause is the last exception in the command output.
+    """
+    sources = [
+        (step_data.get("output"), step_data.get("traceback"))
+        for _, step_status, step_data in steps
+        if step_status != "Success" and isinstance(step_data, dict)
+    ]
+    if isinstance(data, dict) and "output" in data:
+        sources.append((data.get("output"), data.get("traceback")))
+
+    for output, tb in sources:
+        reason = exception_line(output) or exception_line(tb)
+        if reason:
+            return reason
+    for output, tb in sources:
+        reason = last_meaningful_line(output) or last_meaningful_line(tb)
+        if reason:
+            return reason
+    return ""
+
+
+def exception_line(text: str | None) -> str | None:
+    for line in meaningful_lines(text):
+        if EXCEPTION_LINE.match(line):
+            return line
+    return None
+
+
+def last_meaningful_line(text: str | None) -> str | None:
+    for line in meaningful_lines(text):
+        return line
+    return None
+
+
+def meaningful_lines(text: str | None):
+    for line in reversed((text or "").splitlines()):
+        line = line.strip()
+        if line and not line.startswith(TRACEBACK_NOISE):
+            yield line
+
+
+def load_json(raw: str | None):
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except (ValueError, TypeError):
+        return None

--- a/agent/server.py
+++ b/agent/server.py
@@ -227,6 +227,17 @@ class Server(Base):
             self.disable_production_on_bench(bench_name)
             self._move_bench_to_archived_directory(bench_name)
 
+    @job("Fetch Backup Jobs")
+    def fetch_backup_jobs(self, site: str, start: str, end: str):
+        return self._fetch_backup_jobs(site, start, end)
+
+    @step("Fetch Backup Jobs")
+    def _fetch_backup_jobs(self, site: str, start: str, end: str):
+        """Walking the job database can take seconds, so it runs here and not in a worker."""
+        from agent.backup_log import get_backup_jobs
+
+        return get_backup_jobs(site, start, end)
+
     @job("Push Images to Registry")
     def push_images_to_registry(self, images: list[str], registry_settings: dict[str, str]) -> None:
         return self._push_images_to_registry(images, registry_settings)

--- a/agent/tests/test_backup_log.py
+++ b/agent/tests/test_backup_log.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import unittest
 from datetime import datetime
+from unittest.mock import patch
 
 from peewee import SqliteDatabase
 
@@ -63,7 +64,7 @@ class TestBackupLog(unittest.TestCase):
     def test_a_backup_job_is_reported_with_its_artifact_sizes(self):
         self.add_job(sizes={"database": 4096, "public": 8, "private": 16, "site_config": 32})
 
-        jobs = get_backup_jobs(SITE, "2023-10-01", "2023-10-03")
+        jobs = get_backup_jobs(SITE, "2023-10-01", "2023-10-03")["jobs"]
 
         self.assertEqual(len(jobs), 1)
         self.assertEqual(
@@ -74,38 +75,38 @@ class TestBackupLog(unittest.TestCase):
     def test_another_sites_backup_is_not_reported(self):
         self.add_job(site=OTHER_SITE)
 
-        self.assertEqual(get_backup_jobs(SITE, "2023-10-01", "2023-10-03"), [])
+        self.assertEqual(get_backup_jobs(SITE, "2023-10-01", "2023-10-03")["jobs"], [])
 
     def test_a_site_whose_name_contains_the_asked_for_one_is_not_reported(self):
         self.add_job(site=f"not-{SITE}")
 
-        self.assertEqual(get_backup_jobs(SITE, "2023-10-01", "2023-10-03"), [])
+        self.assertEqual(get_backup_jobs(SITE, "2023-10-01", "2023-10-03")["jobs"], [])
 
     def test_jobs_outside_the_range_are_not_reported(self):
         self.add_job(started_on="2023-09-30 04:00:00")
         self.add_job(started_on="2023-10-04 04:00:00")
 
-        self.assertEqual(get_backup_jobs(SITE, "2023-10-01", "2023-10-03"), [])
+        self.assertEqual(get_backup_jobs(SITE, "2023-10-01", "2023-10-03")["jobs"], [])
 
     def test_the_end_date_is_included_whatever_time_the_job_ran(self):
         self.add_job(started_on="2023-10-03 23:59:00")
 
-        self.assertEqual(len(get_backup_jobs(SITE, "2023-10-01", "2023-10-03")), 1)
+        self.assertEqual(len(get_backup_jobs(SITE, "2023-10-01", "2023-10-03")["jobs"]), 1)
 
     def test_jobs_that_are_not_backups_are_not_reported(self):
         self.add_job(name="Migrate Site")
 
-        self.assertEqual(get_backup_jobs(SITE, "2023-10-01", "2023-10-03"), [])
+        self.assertEqual(get_backup_jobs(SITE, "2023-10-01", "2023-10-03")["jobs"], [])
 
     def test_an_offsite_backup_is_labelled_offsite(self):
         self.add_job(offsite=True)
 
-        self.assertEqual(get_backup_jobs(SITE, "2023-10-01", "2023-10-03")[0]["type"], "offsite")
+        self.assertEqual(get_backup_jobs(SITE, "2023-10-01", "2023-10-03")["jobs"][0]["type"], "offsite")
 
     def test_a_local_backup_is_labelled_onsite(self):
         self.add_job(offsite=False)
 
-        self.assertEqual(get_backup_jobs(SITE, "2023-10-01", "2023-10-03")[0]["type"], "onsite")
+        self.assertEqual(get_backup_jobs(SITE, "2023-10-01", "2023-10-03")["jobs"][0]["type"], "onsite")
 
     def test_a_backup_uploaded_by_its_step_is_labelled_offsite(self):
         job = self.add_job(offsite=False)
@@ -117,7 +118,7 @@ class TestBackupLog(unittest.TestCase):
             start=datetime.now(),
         )
 
-        self.assertEqual(get_backup_jobs(SITE, "2023-10-01", "2023-10-03")[0]["type"], "offsite")
+        self.assertEqual(get_backup_jobs(SITE, "2023-10-01", "2023-10-03")["jobs"][0]["type"], "offsite")
 
     def test_a_failure_reports_the_innermost_exception_and_no_traceback(self):
         job = self.add_job(status="Failure")
@@ -138,7 +139,7 @@ class TestBackupLog(unittest.TestCase):
             start=datetime.now(),
         )
 
-        reported = get_backup_jobs(SITE, "2023-10-01", "2023-10-03")[0]
+        reported = get_backup_jobs(SITE, "2023-10-01", "2023-10-03")["jobs"][0]
 
         self.assertEqual(reported["failure_reason"], "MySQLdb.OperationalError: gone away")
         self.assertNotIn("traceback", reported)
@@ -146,20 +147,48 @@ class TestBackupLog(unittest.TestCase):
     def test_a_successful_job_reports_no_failure_reason(self):
         self.add_job()
 
-        self.assertEqual(get_backup_jobs(SITE, "2023-10-01", "2023-10-03")[0]["failure_reason"], "")
+        self.assertEqual(get_backup_jobs(SITE, "2023-10-01", "2023-10-03")["jobs"][0]["failure_reason"], "")
 
     def test_a_job_with_unreadable_data_is_skipped_rather_than_raising(self):
         self.add_job(data="not json")
 
-        self.assertEqual(get_backup_jobs(SITE, "2023-10-01", "2023-10-03"), [])
+        self.assertEqual(get_backup_jobs(SITE, "2023-10-01", "2023-10-03")["jobs"], [])
 
     def test_newest_job_is_reported_first(self):
         self.add_job(started_on="2023-10-01 04:00:00")
         self.add_job(started_on="2023-10-03 04:00:00")
 
-        jobs = get_backup_jobs(SITE, "2023-10-01", "2023-10-03")
+        jobs = get_backup_jobs(SITE, "2023-10-01", "2023-10-03")["jobs"]
 
         self.assertEqual([job["start"] for job in jobs], ["2023-10-03 04:00:00", "2023-10-01 04:00:00"])
+
+    def test_a_similarly_named_site_does_not_consume_the_row_limit(self):
+        # Newer decoys would fill a limit applied before the exact site filter, and the
+        # older real job is the one an audit of a past date is asking about
+        self.add_job(site=SITE, started_on="2023-10-01 04:00:00")
+        for hour in range(2, 5):
+            self.add_job(site=f"not-{SITE}", started_on=f"2023-10-02 0{hour}:00:00")
+
+        with patch("agent.backup_log.MAX_JOBS", 2):
+            jobs = get_backup_jobs(SITE, "2023-10-01", "2023-10-03")
+
+        self.assertEqual(len(jobs["jobs"]), 1)
+        self.assertEqual(jobs["jobs"][0]["start"], "2023-10-01 04:00:00")
+
+    def test_hitting_the_row_limit_is_reported_rather_than_passed_off_as_complete(self):
+        self.add_job(started_on="2023-10-01 04:00:00")
+        self.add_job(started_on="2023-10-02 04:00:00")
+
+        with patch("agent.backup_log.MAX_JOBS", 1):
+            result = get_backup_jobs(SITE, "2023-10-01", "2023-10-03")
+
+        self.assertTrue(result["truncated"])
+        self.assertEqual(len(result["jobs"]), 1)
+
+    def test_a_result_that_fits_is_not_reported_as_truncated(self):
+        self.add_job()
+
+        self.assertFalse(get_backup_jobs(SITE, "2023-10-01", "2023-10-03")["truncated"])
 
     def test_a_malformed_date_is_rejected(self):
         self.assertRaisesRegex(InvalidRange, "YYYY-MM-DD", get_backup_jobs, SITE, "02-10-2023", "2023-10-03")

--- a/agent/tests/test_backup_log.py
+++ b/agent/tests/test_backup_log.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import json
+import unittest
+from datetime import datetime
+
+from peewee import SqliteDatabase
+
+from agent.backup_log import InvalidRange, get_backup_jobs
+from agent.job import JobModel, StepModel
+
+SITE = "audited.frappe.cloud"
+OTHER_SITE = "other.frappe.cloud"
+
+BACKUP_DIRECTORY = "/home/frappe/frappe-bench/sites/{site}/private/backups"
+
+
+def backup_data(site: str, offsite: bool = False, sizes: dict | None = None) -> str:
+    """A Backup Site job's data, shaped the way fetch_latest_backup returns it."""
+    sizes = sizes or {"database": 2048, "public": 512, "private": 128, "site_config": 16}
+    backups = {
+        artifact: {
+            "path": f"{BACKUP_DIRECTORY.format(site=site)}/20231002_000502-{artifact}",
+            "file": f"20231002_000502-{artifact}",
+            "size": size,
+            "url": f"https://{site}/backups/20231002_000502-{artifact}",
+        }
+        for artifact, size in sizes.items()
+    }
+    return json.dumps({"backups": backups, "offsite": {"a-file": "path/to/a-file"} if offsite else {}})
+
+
+class TestBackupLog(unittest.TestCase):
+    def setUp(self):
+        self.database = SqliteDatabase(":memory:")
+        self.models = [JobModel, StepModel]
+        self.database.bind(self.models)
+        self.database.connect()
+        self.database.create_tables(self.models)
+
+    def tearDown(self):
+        self.database.drop_tables(self.models)
+        self.database.close()
+
+    def add_job(
+        self,
+        site: str = SITE,
+        name: str = "Backup Site",
+        status: str = "Success",
+        started_on: str = "2023-10-02 04:00:00",
+        offsite: bool = False,
+        sizes: dict | None = None,
+        data: str | None = None,
+    ) -> JobModel:
+        return JobModel.create(
+            name=name,
+            status=status,
+            agent_job_id="1",
+            data=data if data is not None else backup_data(site, offsite, sizes),
+            start=datetime.strptime(started_on, "%Y-%m-%d %H:%M:%S"),
+        )
+
+    def test_a_backup_job_is_reported_with_its_artifact_sizes(self):
+        self.add_job(sizes={"database": 4096, "public": 8, "private": 16, "site_config": 32})
+
+        jobs = get_backup_jobs(SITE, "2023-10-01", "2023-10-03")
+
+        self.assertEqual(len(jobs), 1)
+        self.assertEqual(
+            jobs[0]["sizes"],
+            {"database": 4096, "public": 8, "private": 16, "site_config": 32},
+        )
+
+    def test_another_sites_backup_is_not_reported(self):
+        self.add_job(site=OTHER_SITE)
+
+        self.assertEqual(get_backup_jobs(SITE, "2023-10-01", "2023-10-03"), [])
+
+    def test_a_site_whose_name_contains_the_asked_for_one_is_not_reported(self):
+        self.add_job(site=f"not-{SITE}")
+
+        self.assertEqual(get_backup_jobs(SITE, "2023-10-01", "2023-10-03"), [])
+
+    def test_jobs_outside_the_range_are_not_reported(self):
+        self.add_job(started_on="2023-09-30 04:00:00")
+        self.add_job(started_on="2023-10-04 04:00:00")
+
+        self.assertEqual(get_backup_jobs(SITE, "2023-10-01", "2023-10-03"), [])
+
+    def test_the_end_date_is_included_whatever_time_the_job_ran(self):
+        self.add_job(started_on="2023-10-03 23:59:00")
+
+        self.assertEqual(len(get_backup_jobs(SITE, "2023-10-01", "2023-10-03")), 1)
+
+    def test_jobs_that_are_not_backups_are_not_reported(self):
+        self.add_job(name="Migrate Site")
+
+        self.assertEqual(get_backup_jobs(SITE, "2023-10-01", "2023-10-03"), [])
+
+    def test_an_offsite_backup_is_labelled_offsite(self):
+        self.add_job(offsite=True)
+
+        self.assertEqual(get_backup_jobs(SITE, "2023-10-01", "2023-10-03")[0]["type"], "offsite")
+
+    def test_a_local_backup_is_labelled_onsite(self):
+        self.add_job(offsite=False)
+
+        self.assertEqual(get_backup_jobs(SITE, "2023-10-01", "2023-10-03")[0]["type"], "onsite")
+
+    def test_a_backup_uploaded_by_its_step_is_labelled_offsite(self):
+        job = self.add_job(offsite=False)
+        StepModel.create(
+            name="Upload Site Backup to S3",
+            job=job,
+            status="Success",
+            data="{}",
+            start=datetime.now(),
+        )
+
+        self.assertEqual(get_backup_jobs(SITE, "2023-10-01", "2023-10-03")[0]["type"], "offsite")
+
+    def test_a_failure_reports_the_innermost_exception_and_no_traceback(self):
+        job = self.add_job(status="Failure")
+        StepModel.create(
+            name="Backup Site",
+            job=job,
+            status="Failure",
+            data=json.dumps(
+                {
+                    "output": (
+                        "Traceback (most recent call last):\n"
+                        '  File "x.py", line 1\n'
+                        "MySQLdb.OperationalError: gone away"
+                    ),
+                    "traceback": "subprocess.CalledProcessError: command failed",
+                }
+            ),
+            start=datetime.now(),
+        )
+
+        reported = get_backup_jobs(SITE, "2023-10-01", "2023-10-03")[0]
+
+        self.assertEqual(reported["failure_reason"], "MySQLdb.OperationalError: gone away")
+        self.assertNotIn("traceback", reported)
+
+    def test_a_successful_job_reports_no_failure_reason(self):
+        self.add_job()
+
+        self.assertEqual(get_backup_jobs(SITE, "2023-10-01", "2023-10-03")[0]["failure_reason"], "")
+
+    def test_a_job_with_unreadable_data_is_skipped_rather_than_raising(self):
+        self.add_job(data="not json")
+
+        self.assertEqual(get_backup_jobs(SITE, "2023-10-01", "2023-10-03"), [])
+
+    def test_newest_job_is_reported_first(self):
+        self.add_job(started_on="2023-10-01 04:00:00")
+        self.add_job(started_on="2023-10-03 04:00:00")
+
+        jobs = get_backup_jobs(SITE, "2023-10-01", "2023-10-03")
+
+        self.assertEqual([job["start"] for job in jobs], ["2023-10-03 04:00:00", "2023-10-01 04:00:00"])
+
+    def test_a_malformed_date_is_rejected(self):
+        self.assertRaisesRegex(InvalidRange, "YYYY-MM-DD", get_backup_jobs, SITE, "02-10-2023", "2023-10-03")
+
+    def test_a_missing_date_is_rejected(self):
+        self.assertRaisesRegex(InvalidRange, "YYYY-MM-DD", get_backup_jobs, SITE, None, None)
+
+    def test_a_reversed_range_is_rejected(self):
+        self.assertRaisesRegex(
+            InvalidRange, "on or before", get_backup_jobs, SITE, "2023-10-03", "2023-10-01"
+        )
+
+    def test_a_range_wider_than_a_year_is_rejected(self):
+        self.assertRaisesRegex(
+            InvalidRange, "366 days or less", get_backup_jobs, SITE, "2023-01-01", "2024-12-31"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agent/web.py
+++ b/agent/web.py
@@ -16,7 +16,7 @@ from rq.exceptions import NoSuchJobError
 from rq.job import Job as RQJob
 from rq.job import JobStatus
 
-from agent.backup_log import InvalidRange, get_backup_jobs
+from agent.backup_log import InvalidRange, parse_range
 from agent.base import AgentException
 from agent.builder import ImageBuilder, PatchImageBuilder
 from agent.database import JSONEncoderForSQLQueryResult
@@ -1676,19 +1676,25 @@ def jobs(id=None, ids=None, status=None):
     return jsonify(json.loads(json.dumps(data, default=str)))
 
 
-@application.route("/sites/<string:site>/backup-jobs")
-def site_backup_jobs(site):
-    """Backup Site jobs this server ran for one site, for an audit of a past date.
+@application.route("/server/backup-jobs", methods=["POST"])
+def fetch_backup_jobs():
+    """Queue a read of the job database for one site's backups, for an audit of a past date.
 
-    Scoped to the named site and a bounded date range, so it cannot be used to walk
-    the whole job database or read another site's runs.
+    Scoped to the named site and a bounded date range, so it cannot be used to walk the
+    whole job database or read another site's runs. The range is checked here so a bad
+    one is a failed request rather than a failed job.
     """
+    site = request.args.get("site")
+    if not site:
+        return jsonify({"message": "site is required"}), 400
+
     try:
-        result = get_backup_jobs(site, request.args.get("start"), request.args.get("end"))
+        parse_range(request.args.get("start"), request.args.get("end"))
     except InvalidRange as e:
         return jsonify({"message": str(e)}), 400
 
-    return jsonify({"site": site, **result})
+    job = Server().fetch_backup_jobs(site, request.args.get("start"), request.args.get("end"))
+    return {"job": job}
 
 
 @application.route("/jobs/<int:id>/cancel", methods=["POST"])

--- a/agent/web.py
+++ b/agent/web.py
@@ -1684,11 +1684,11 @@ def site_backup_jobs(site):
     the whole job database or read another site's runs.
     """
     try:
-        jobs = get_backup_jobs(site, request.args.get("start"), request.args.get("end"))
+        result = get_backup_jobs(site, request.args.get("start"), request.args.get("end"))
     except InvalidRange as e:
         return jsonify({"message": str(e)}), 400
 
-    return jsonify({"site": site, "jobs": jobs})
+    return jsonify({"site": site, **result})
 
 
 @application.route("/jobs/<int:id>/cancel", methods=["POST"])

--- a/agent/web.py
+++ b/agent/web.py
@@ -16,6 +16,7 @@ from rq.exceptions import NoSuchJobError
 from rq.job import Job as RQJob
 from rq.job import JobStatus
 
+from agent.backup_log import InvalidRange, get_backup_jobs
 from agent.base import AgentException
 from agent.builder import ImageBuilder, PatchImageBuilder
 from agent.database import JSONEncoderForSQLQueryResult
@@ -1673,6 +1674,21 @@ def jobs(id=None, ids=None, status=None):
         data = get_jobs(limit=100)
 
     return jsonify(json.loads(json.dumps(data, default=str)))
+
+
+@application.route("/sites/<string:site>/backup-jobs")
+def site_backup_jobs(site):
+    """Backup Site jobs this server ran for one site, for an audit of a past date.
+
+    Scoped to the named site and a bounded date range, so it cannot be used to walk
+    the whole job database or read another site's runs.
+    """
+    try:
+        jobs = get_backup_jobs(site, request.args.get("start"), request.args.get("end"))
+    except InvalidRange as e:
+        return jsonify({"message": str(e)}), 400
+
+    return jsonify({"site": site, "jobs": jobs})
 
 
 @application.route("/jobs/<int:id>/cancel", methods=["POST"])


### PR DESCRIPTION
An audit asks whether a backup ran on some past date. Press answers from its own records, but a site that has moved between servers leaves its older jobs behind on the server that ran them, and the job database is the only place those survive.

GET /sites/<site>/backup-jobs?start=&end= reports the Backup Site jobs for one site: status, timings, artifact sizes, and whether it went offsite. Parsing follows fc-scripts/create_backup_log.py, which reads jobs.sqlite3 directly today.

The site is matched on the backup paths the agent itself recorded rather than the bench command, which is caller-supplied. A LIKE only narrows the scan. Failures report one interpreted exception line instead of the raw traceback, and the range is capped so a call cannot walk the whole database.