### PR TITLE
feat(pages): Redesign the error pages

### DIFF
--- a/agent/pages/bad_gateway.html
+++ b/agent/pages/bad_gateway.html
@@ -2,169 +2,142 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Bad Gateway</title>
     <style>
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
       html {
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
+        color-scheme: light;
       }
+
       body {
         font-family:
           -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
-          Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
-        color: #1a4469;
-        background-color: #f9fafa;
+          Cantarell, "Helvetica Neue", sans-serif;
+        background-color: #ffffff;
+        color: #171717;
+        min-height: 100vh;
+        padding: 24px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 48px;
       }
 
-      .container {
-        padding-top: 4rem;
-        max-width: 768px;
-        margin: 0 auto;
-      }
-
-      .logo {
+      .content {
+        max-width: 26rem;
         text-align: center;
         display: flex;
-        justify-content: center;
+        flex-direction: column;
         align-items: center;
+        gap: 16px;
       }
 
-      .logo svg {
-        height: 2rem;
-      }
-
-      .logo h1 {
-        font-size: 18px;
-        font-weight: 600;
-        color: #171717;
-      }
-
-      .message-container {
-        width: 24rem;
-        margin: 0 auto;
-        background-color: white;
-        padding: 2.5rem;
-        margin-top: 1.5rem;
-        -webkit-box-shadow:
-          0 4px 6px -1px rgba(0, 0, 0, 0.1),
-          0 2px 4px -1px rgba(0, 0, 0, 0.06);
-        box-shadow:
-          0 4px 6px -1px rgba(0, 0, 0, 0.1),
-          0 2px 4px -1px rgba(0, 0, 0, 0.06);
-        font-size: 13px;
-        text-align: center;
-        border-radius: 0.375rem;
-      }
-
-      .alert-icon svg {
-        height: 2rem;
-        width: 2rem;
+      .text {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
       }
 
       h1 {
-        font-size: 16px;
-        font-weight: 500;
+        font-size: 20px;
+        font-weight: 600;
+        line-height: 1.3;
       }
 
       p {
-        color: #4c5a67;
+        font-size: 14px;
         line-height: 1.5;
+        color: #525252;
+      }
+
+      .footer {
+        font-size: 14px;
+        line-height: 1.5;
+        text-align: center;
+        color: #7c7c7c;
       }
 
       a {
-        color: #1579d0;
+        color: #0070cc;
+      }
+
+      /* plain-html visited purple. must not reach .button, whose label is white */
+      a:not(.button):visited {
+        color: #551a8b;
+      }
+
+      .button {
+        display: inline-flex;
+        align-items: center;
+        padding: 8px 12px;
+        border-radius: 8px;
+        background-color: #171717;
+        color: #ffffff;
+        font-size: 14px;
         text-decoration: none;
-        border-bottom: 1px solid #1579d0;
+      }
+
+      .button:hover {
+        background-color: #2f2f2f;
       }
     </style>
   </head>
-
   <body>
-    <div class="container">
-      <div class="logo">
-        <svg
-          width="40"
-          height="100"
-          viewBox="0 0 160 120"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M93.4626 0H23.5665C10.5511 0 0 10.5511 0 23.5665V93.4626C0 106.478 10.5511 117.029 23.5665 117.029H93.4626C106.478 117.029 117.029 106.478 117.029 93.4626V23.5665C117.029 10.5511 106.478 0 93.4626 0Z"
-            fill="url(#paint0_radial_0_9)"
-          />
-          <path
-            d="M94.4529 48.9854C89.7801 42.265 81.9046 38.3798 73.7142 38.9048C70.1965 32.552 63.6861 28.3517 56.0732 27.8792C50.7704 27.5642 45.4151 29.4018 41.2674 32.972C38.4322 35.4396 36.3846 38.2748 35.1245 41.4775C34.3895 43.3676 32.7094 44.5751 30.9243 44.5751H18.3761V55.0757H30.9243C37.0671 55.0757 42.5799 51.243 44.8901 45.3102C45.5201 43.6826 46.5702 42.265 48.1453 40.8999C50.1929 39.1148 52.8705 38.1698 55.3907 38.3273C59.1709 38.5898 61.8485 40.3224 63.5286 42.475C65.3137 44.4701 66.3113 47.5678 66.8888 50.6655C70.249 49.7204 73.9242 48.9329 77.4419 49.5104C80.3296 49.9829 83.0072 51.5055 84.9498 53.7631C85.2648 54.1307 85.5798 54.4982 85.8424 54.9182C88.3625 58.5409 88.835 63.0037 87.1549 67.4139C85.6324 71.5091 80.0145 75.2369 75.3418 75.2369H38.7997C33.8119 75.2369 29.7167 71.5091 29.0867 66.7314H18.5861C19.2686 77.337 28.0366 85.7374 38.7997 85.7374H75.3943C84.4248 85.7374 93.9278 79.3321 97.0255 71.1416C99.9132 63.4762 98.9681 55.3907 94.5054 48.9329L94.4529 48.9854Z"
-            fill="#FFFAE9"
-          />
-          <defs>
-            <radialGradient
-              id="paint0_radial_0_9"
-              cx="0"
-              cy="0"
-              r="1"
-              gradientUnits="userSpaceOnUse"
-              gradientTransform="translate(-28.5 -58) rotate(54.335) scale(209.246)"
-            >
-              <stop stop-color="#40D1FF" />
-              <stop offset="1" stop-color="#0097FF" />
-            </radialGradient>
-          </defs>
-        </svg>
-        <div class="logo-text">
-          <h1>Frappe Cloud</h1>
-        </div>
+    <div class="content">
+      <svg
+        width="40"
+        height="40"
+        viewBox="0 0 40 40"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        <path
+          d="M17.4 5.5a3 3 0 0 1 5.2 0l14.1 24.5a3 3 0 0 1-2.6 4.5H5.9a3 3 0 0 1-2.6-4.5L17.4 5.5Z"
+          stroke="#E5484D"
+          stroke-width="2.5"
+          stroke-linejoin="round"
+        />
+        <path
+          d="M20 15.5v6.5"
+          stroke="#E5484D"
+          stroke-width="2.5"
+          stroke-linecap="round"
+        />
+        <circle cx="20" cy="27.5" r="1.75" fill="#E5484D" />
+      </svg>
+      <div class="text">
+        <h1>This site is not responding</h1>
+        <p>Error: 502 Bad Gateway</p>
       </div>
-      <div class="message-container">
-        <div class="alert-icon">
-          <!-- Red filled circle with white exclamation mark (scaled down via CSS) -->
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
-            <circle cx="12" cy="12" r="10" fill="#EF4444" stroke="#EF4444" />
-            <line x1="12" x2="12" y1="8" y2="12" stroke="white" />
-            <line x1="12" x2="12.01" y1="16" y2="16" stroke="white" />
-          </svg>
-        </div>
-        <h1>Bad Gateway</h1>
-        <p class="message">
-          Your bench appears to be down.
-          <a
-            href="https://docs.frappe.io/cloud/site/common-issues/502-bad-gateway"
-            style="
-              display: inline-block;
-              margin-top: 10px;
-              padding: 8px 16px;
-              background: #f5f5f5;
-              border-radius: 4px;
-              color: #333;
-              text-decoration: none;
-              font-weight: bold;
-              border: 1px solid #e0e0e0;
-            "
-          >
-            📄 Follow the step-by-step guide to debug this issue
-          </a>
-        </p>
-        <p>
-          If you are the owner of this site, please check the error logs on your
-          site's
-          <a class="dashboard-url" href="https://frappecloud.com/dashboard"
-            ><strong>dashboard</strong></a
-          >.
-        </p>
-      </div>
+      <a
+        class="button"
+        href="https://docs.frappe.io/cloud/site/common-issues/502-bad-gateway"
+        >View troubleshooting guide</a
+      >
     </div>
+    <p class="footer">
+      Site owner? Check the
+      <a class="dashboard-url" href="https://frappecloud.com/dashboard"
+        >dashboard</a
+      >
+      for the current status of your bench.
+    </p>
+    <script>
+      // the dashboard link needs the site name, which only the browser knows here
+      document.querySelector(".dashboard-url").href =
+        `https://frappecloud.com/dashboard/sites/${window.location.hostname}`;
+    </script>
   </body>
-
-  <script>
-    const dashboardUrl = document.querySelector(".dashboard-url");
-    const siteName = window.location.hostname;
-    dashboardUrl.href = `https://frappecloud.com/dashboard/sites/${siteName}`;
-  </script>
 </html>

--- a/agent/pages/deactivated.html
+++ b/agent/pages/deactivated.html
@@ -1,123 +1,132 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <title>This Site is Inactive</title>
-        <style>
-            html {
-                -webkit-font-smoothing: antialiased;
-                -moz-osx-font-smoothing: grayscale;
-            }
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>This Site is Inactive</title>
+    <style>
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
 
-            body {
-                font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-                color: #1A4469;
-                background-color: #F9FAFA;
-            }
+      html {
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+        color-scheme: light;
+      }
 
-            .container {
-                padding-top: 4rem;
-                max-width: 768px;
-                margin: 0 auto;
-            }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
+          Cantarell, "Helvetica Neue", sans-serif;
+        background-color: #ffffff;
+        color: #171717;
+        min-height: 100vh;
+        padding: 24px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 48px;
+      }
 
-            .logo {
-                text-align: center;
-                display: flex;
-                justify-content: center;
-                align-items: center;
-            }
+      .content {
+        max-width: 26rem;
+        text-align: center;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 16px;
+      }
 
-            .logo svg {
-                height: 2rem;
-            }
+      .text {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
 
-            .logo h1 {
-                font-size: 18px;
-                font-weight: 600;
-                color: #171717;
-            }
+      h1 {
+        font-size: 20px;
+        font-weight: 600;
+        line-height: 1.3;
+      }
 
-            .message-container {
-                width: 24rem;
-                margin: 0 auto;
-                background-color: white;
-                padding: 2.5rem;
-                margin-top: 1.5rem;
-                -webkit-box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-                box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-                font-size: 13px;
-                text-align: center;
-                border-radius: 0.375rem;
-            }
+      p {
+        font-size: 14px;
+        line-height: 1.5;
+        color: #525252;
+      }
 
-            .alert-icon svg {
-                height: 2rem;
-                width: 2rem;
-            }
+      .footer {
+        font-size: 14px;
+        line-height: 1.5;
+        text-align: center;
+        color: #7c7c7c;
+      }
 
-            h1 {
-                font-size: 16px;
-                font-weight: 500;
-            }
+      a {
+        color: #0070cc;
+      }
 
-            p {
-                color: #4C5A67;
-                line-height: 1.5;
-            }
+      /* plain-html visited purple. must not reach .button, whose label is white */
+      a:not(.button):visited {
+        color: #551a8b;
+      }
 
-            a {
-                color: #1579D0;
-                text-decoration: none;
-                border-bottom: 1px solid #1579D0;
-            }
-        </style>
-    </head>
+      .button {
+        display: inline-flex;
+        align-items: center;
+        padding: 8px 12px;
+        border-radius: 8px;
+        background-color: #171717;
+        color: #ffffff;
+        font-size: 14px;
+        text-decoration: none;
+      }
 
-    <body>
-        <div class="container">
-            <div class="logo">
-                <svg width="40" height="100" viewBox="0 0 160 120" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path
-                        d="M93.4626 0H23.5665C10.5511 0 0 10.5511 0 23.5665V93.4626C0 106.478 10.5511 117.029 23.5665 117.029H93.4626C106.478 117.029 117.029 106.478 117.029 93.4626V23.5665C117.029 10.5511 106.478 0 93.4626 0Z"
-                        fill="url(#paint0_radial_0_9)" />
-                    <path
-                        d="M94.4529 48.9854C89.7801 42.265 81.9046 38.3798 73.7142 38.9048C70.1965 32.552 63.6861 28.3517 56.0732 27.8792C50.7704 27.5642 45.4151 29.4018 41.2674 32.972C38.4322 35.4396 36.3846 38.2748 35.1245 41.4775C34.3895 43.3676 32.7094 44.5751 30.9243 44.5751H18.3761V55.0757H30.9243C37.0671 55.0757 42.5799 51.243 44.8901 45.3102C45.5201 43.6826 46.5702 42.265 48.1453 40.8999C50.1929 39.1148 52.8705 38.1698 55.3907 38.3273C59.1709 38.5898 61.8485 40.3224 63.5286 42.475C65.3137 44.4701 66.3113 47.5678 66.8888 50.6655C70.249 49.7204 73.9242 48.9329 77.4419 49.5104C80.3296 49.9829 83.0072 51.5055 84.9498 53.7631C85.2648 54.1307 85.5798 54.4982 85.8424 54.9182C88.3625 58.5409 88.835 63.0037 87.1549 67.4139C85.6324 71.5091 80.0145 75.2369 75.3418 75.2369H38.7997C33.8119 75.2369 29.7167 71.5091 29.0867 66.7314H18.5861C19.2686 77.337 28.0366 85.7374 38.7997 85.7374H75.3943C84.4248 85.7374 93.9278 79.3321 97.0255 71.1416C99.9132 63.4762 98.9681 55.3907 94.5054 48.9329L94.4529 48.9854Z"
-                        fill="#FFFAE9" />
-                    <defs>
-                        <radialGradient id="paint0_radial_0_9" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse"
-                            gradientTransform="translate(-28.5 -58) rotate(54.335) scale(209.246)">
-                            <stop stop-color="#40D1FF" />
-                            <stop offset="1" stop-color="#0097FF" />
-                        </radialGradient>
-                    </defs>
-                </svg>
-                <div class="logo-text">
-                    <h1>Frappe Cloud</h1>
-                </div>
-            </div>
-            <div class="message-container">
-                <div class="alert-icon">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <path fill-rule="evenodd" clip-rule="evenodd"
-                            d="M4.00288 21.3966C2.47791 21.3966 1.51397 19.7584 2.25456 18.4253L10.2527 4.02871C11.0147 2.65709 12.9873 2.6571 13.7493 4.02872L21.7474 18.4253C22.488 19.7584 21.524 21.3966 19.9991 21.3966H4.00288ZM11.9991 18.4126C12.5688 18.4126 13.0307 17.9507 13.0307 17.381C13.0307 16.8113 12.5688 16.3495 11.9991 16.3495C11.4294 16.3495 10.9675 16.8113 10.9675 17.381C10.9675 17.9507 11.4294 18.4126 11.9991 18.4126ZM13 8.8601C13 8.30782 12.5523 7.8601 12 7.8601C11.4477 7.8601 11 8.30782 11 8.8601V13.9074C11 14.4597 11.4477 14.9074 12 14.9074C12.5523 14.9074 13 14.4597 13 13.9074V8.8601Z"
-                            fill="#D6932E" />
-                    </svg>
-                </div>
-                <h1>
-                    This Site is Inactive.
-                </h1>
-                <p class="message">
-                    This site has been deactivated. If you are the owner of this site, you can activate it from your
-                    <a class="dashboard-url" href="https://frappecloud.com/dashboard">Frappe Cloud Dashboard</a>.
-                </p>
-            </div>
-        </div>
-    </body>
-
+      .button:hover {
+        background-color: #2f2f2f;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="content">
+      <svg
+        width="40"
+        height="40"
+        viewBox="0 0 40 40"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        <circle cx="20" cy="20" r="16.5" stroke="#E79913" stroke-width="2.5" />
+        <path
+          d="M20 12v9"
+          stroke="#E79913"
+          stroke-width="2.5"
+          stroke-linecap="round"
+        />
+        <circle cx="20" cy="26.5" r="1.75" fill="#E79913" />
+      </svg>
+      <div class="text">
+        <h1>This site is inactive</h1>
+        <p>The site has been deactivated.</p>
+      </div>
+    </div>
+    <p class="footer">
+      Site owner? Activate it again from the
+      <a class="dashboard-url" href="https://frappecloud.com/dashboard"
+        >dashboard</a
+      >.
+    </p>
     <script>
-        const dashboardUrl = document.querySelector('.dashboard-url');
-        const siteName = window.location.hostname;
-        dashboardUrl.href = `https://frappecloud.com/dashboard/sites/${siteName}`;
+      // the dashboard link needs the site name, which only the browser knows here
+      document.querySelector(".dashboard-url").href =
+        `https://frappecloud.com/dashboard/sites/${window.location.hostname}`;
     </script>
+  </body>
 </html>

--- a/agent/pages/exceeded.html
+++ b/agent/pages/exceeded.html
@@ -1,125 +1,134 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-
-<head>
-    <meta charset="utf-8">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Daily Usage Limit Reached</title>
     <style>
-        html {
-            -webkit-font-smoothing: antialiased;
-            -moz-osx-font-smoothing: grayscale;
-        }
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
 
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-            color: #1A4469;
-            background-color: #F9FAFA;
-        }
+      html {
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+        color-scheme: light;
+      }
 
-        .container {
-            padding-top: 4rem;
-            max-width: 768px;
-            margin: 0 auto;
-        }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
+          Cantarell, "Helvetica Neue", sans-serif;
+        background-color: #ffffff;
+        color: #171717;
+        min-height: 100vh;
+        padding: 24px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 48px;
+      }
 
-        .logo {
-            text-align: center;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-        }
+      .content {
+        max-width: 26rem;
+        text-align: center;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 16px;
+      }
 
-        .logo svg {
-            height: 2rem;
-        }
+      .text {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
 
-        .logo h1 {
-            font-size: 18px;
-            font-weight: 600;
-            color: #171717;
-        }
+      h1 {
+        font-size: 20px;
+        font-weight: 600;
+        line-height: 1.3;
+      }
 
-        .message-container {
-            width: 24rem;
-            margin: 0 auto;
-            background-color: white;
-            padding: 2.5rem;
-            margin-top: 1.5rem;
-            -webkit-box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-            font-size: 13px;
-            text-align: center;
-            border-radius: 0.375rem;
-        }
+      p {
+        font-size: 14px;
+        line-height: 1.5;
+        color: #525252;
+      }
 
-        .alert-icon svg {
-            height: 2rem;
-            width: 2rem;
-        }
+      .footer {
+        font-size: 14px;
+        line-height: 1.5;
+        text-align: center;
+        color: #7c7c7c;
+      }
 
-        h1 {
-            font-size: 16px;
-            font-weight: 500;
-        }
+      a {
+        color: #0070cc;
+      }
 
-        p {
-            color: #4C5A67;
-            line-height: 1.5;
-        }
+      /* plain-html visited purple. must not reach .button, whose label is white */
+      a:not(.button):visited {
+        color: #551a8b;
+      }
 
-        a {
-            color: #1579D0;
-            text-decoration: none;
-            border-bottom: 1px solid #1579D0;
-        }
+      .button {
+        display: inline-flex;
+        align-items: center;
+        padding: 8px 12px;
+        border-radius: 8px;
+        background-color: #171717;
+        color: #ffffff;
+        font-size: 14px;
+        text-decoration: none;
+      }
+
+      .button:hover {
+        background-color: #2f2f2f;
+      }
     </style>
-</head>
-
-<body>
-    <div class="container">
-        <div class="logo">
-            <svg width="40" height="100" viewBox="0 0 160 120" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path
-                    d="M93.4626 0H23.5665C10.5511 0 0 10.5511 0 23.5665V93.4626C0 106.478 10.5511 117.029 23.5665 117.029H93.4626C106.478 117.029 117.029 106.478 117.029 93.4626V23.5665C117.029 10.5511 106.478 0 93.4626 0Z"
-                    fill="url(#paint0_radial_0_9)" />
-                <path
-                    d="M94.4529 48.9854C89.7801 42.265 81.9046 38.3798 73.7142 38.9048C70.1965 32.552 63.6861 28.3517 56.0732 27.8792C50.7704 27.5642 45.4151 29.4018 41.2674 32.972C38.4322 35.4396 36.3846 38.2748 35.1245 41.4775C34.3895 43.3676 32.7094 44.5751 30.9243 44.5751H18.3761V55.0757H30.9243C37.0671 55.0757 42.5799 51.243 44.8901 45.3102C45.5201 43.6826 46.5702 42.265 48.1453 40.8999C50.1929 39.1148 52.8705 38.1698 55.3907 38.3273C59.1709 38.5898 61.8485 40.3224 63.5286 42.475C65.3137 44.4701 66.3113 47.5678 66.8888 50.6655C70.249 49.7204 73.9242 48.9329 77.4419 49.5104C80.3296 49.9829 83.0072 51.5055 84.9498 53.7631C85.2648 54.1307 85.5798 54.4982 85.8424 54.9182C88.3625 58.5409 88.835 63.0037 87.1549 67.4139C85.6324 71.5091 80.0145 75.2369 75.3418 75.2369H38.7997C33.8119 75.2369 29.7167 71.5091 29.0867 66.7314H18.5861C19.2686 77.337 28.0366 85.7374 38.7997 85.7374H75.3943C84.4248 85.7374 93.9278 79.3321 97.0255 71.1416C99.9132 63.4762 98.9681 55.3907 94.5054 48.9329L94.4529 48.9854Z"
-                    fill="#FFFAE9" />
-                <defs>
-                    <radialGradient id="paint0_radial_0_9" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse"
-                        gradientTransform="translate(-28.5 -58) rotate(54.335) scale(209.246)">
-                        <stop stop-color="#40D1FF" />
-                        <stop offset="1" stop-color="#0097FF" />
-                    </radialGradient>
-                </defs>
-            </svg>
-            <div class="logo-text">
-                <h1>Frappe Cloud</h1>
-            </div>
-        </div>
-        <div class="message-container">
-            <div class="alert-icon">
-                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path fill-rule="evenodd" clip-rule="evenodd"
-                        d="M4.00288 21.3966C2.47791 21.3966 1.51397 19.7584 2.25456 18.4253L10.2527 4.02871C11.0147 2.65709 12.9873 2.6571 13.7493 4.02872L21.7474 18.4253C22.488 19.7584 21.524 21.3966 19.9991 21.3966H4.00288ZM11.9991 18.4126C12.5688 18.4126 13.0307 17.9507 13.0307 17.381C13.0307 16.8113 12.5688 16.3495 11.9991 16.3495C11.4294 16.3495 10.9675 16.8113 10.9675 17.381C10.9675 17.9507 11.4294 18.4126 11.9991 18.4126ZM13 8.8601C13 8.30782 12.5523 7.8601 12 7.8601C11.4477 7.8601 11 8.30782 11 8.8601V13.9074C11 14.4597 11.4477 14.9074 12 14.9074C12.5523 14.9074 13 14.4597 13 13.9074V8.8601Z"
-                        fill="#D6932E" />
-                </svg>
-            </div>
-            <h1>
-                Daily Usage Limit Reached.
-            </h1>
-            <p class="message">
-                Daily usage limit is reached for this site. If you are the owner of this site, you can upgrade your plan
-                from your <a class="dashboard-url" href="https://frappecloud.com/dashboard">Frappe Cloud Dashboard</a>.
-            </p>
-        </div>
+  </head>
+  <body>
+    <div class="content">
+      <svg
+        width="40"
+        height="40"
+        viewBox="0 0 40 40"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        <circle cx="20" cy="20" r="16.5" stroke="#E79913" stroke-width="2.5" />
+        <path
+          d="M20 12v9"
+          stroke="#E79913"
+          stroke-width="2.5"
+          stroke-linecap="round"
+        />
+        <circle cx="20" cy="26.5" r="1.75" fill="#E79913" />
+      </svg>
+      <div class="text">
+        <h1>Daily usage limit reached</h1>
+        <p>
+          This site has used up the compute time included in its plan for today.
+        </p>
+      </div>
     </div>
-</body>
-
-<script>
-    const dashboardUrl = document.querySelector('.dashboard-url');
-    const siteName = window.location.hostname;
-    dashboardUrl.href = `https://frappecloud.com/dashboard/sites/${siteName}`;
-</script>
-
+    <p class="footer">
+      Site owner? Upgrade your plan from the
+      <a class="dashboard-url" href="https://frappecloud.com/dashboard"
+        >dashboard</a
+      >.
+    </p>
+    <script>
+      // the dashboard link needs the site name, which only the browser knows here
+      document.querySelector(".dashboard-url").href =
+        `https://frappecloud.com/dashboard/sites/${window.location.hostname}`;
+    </script>
+  </body>
 </html>

--- a/agent/pages/gateway_timeout.html
+++ b/agent/pages/gateway_timeout.html
@@ -2,169 +2,142 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Gateway Timeout</title>
     <style>
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
       html {
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
+        color-scheme: light;
       }
+
       body {
         font-family:
           -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
-          Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
-        color: #1a4469;
-        background-color: #f9fafa;
+          Cantarell, "Helvetica Neue", sans-serif;
+        background-color: #ffffff;
+        color: #171717;
+        min-height: 100vh;
+        padding: 24px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 48px;
       }
 
-      .container {
-        padding-top: 4rem;
-        max-width: 768px;
-        margin: 0 auto;
-      }
-
-      .logo {
+      .content {
+        max-width: 26rem;
         text-align: center;
         display: flex;
-        justify-content: center;
+        flex-direction: column;
         align-items: center;
+        gap: 16px;
       }
 
-      .logo svg {
-        height: 2rem;
-      }
-
-      .logo h1 {
-        font-size: 18px;
-        font-weight: 600;
-        color: #171717;
-      }
-
-      .message-container {
-        width: 24rem;
-        margin: 0 auto;
-        background-color: white;
-        padding: 2.5rem;
-        margin-top: 1.5rem;
-        -webkit-box-shadow:
-          0 4px 6px -1px rgba(0, 0, 0, 0.1),
-          0 2px 4px -1px rgba(0, 0, 0, 0.06);
-        box-shadow:
-          0 4px 6px -1px rgba(0, 0, 0, 0.1),
-          0 2px 4px -1px rgba(0, 0, 0, 0.06);
-        font-size: 13px;
-        text-align: center;
-        border-radius: 0.375rem;
-      }
-
-      .alert-icon svg {
-        height: 2rem;
-        width: 2rem;
+      .text {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
       }
 
       h1 {
-        font-size: 16px;
-        font-weight: 500;
+        font-size: 20px;
+        font-weight: 600;
+        line-height: 1.3;
       }
 
       p {
-        color: #4c5a67;
+        font-size: 14px;
         line-height: 1.5;
+        color: #525252;
+      }
+
+      .footer {
+        font-size: 14px;
+        line-height: 1.5;
+        text-align: center;
+        color: #7c7c7c;
       }
 
       a {
-        color: #1579d0;
+        color: #0070cc;
+      }
+
+      /* plain-html visited purple. must not reach .button, whose label is white */
+      a:not(.button):visited {
+        color: #551a8b;
+      }
+
+      .button {
+        display: inline-flex;
+        align-items: center;
+        padding: 8px 12px;
+        border-radius: 8px;
+        background-color: #171717;
+        color: #ffffff;
+        font-size: 14px;
         text-decoration: none;
-        border-bottom: 1px solid #1579d0;
+      }
+
+      .button:hover {
+        background-color: #2f2f2f;
       }
     </style>
   </head>
-
   <body>
-    <div class="container">
-      <div class="logo">
-        <svg
-          width="40"
-          height="100"
-          viewBox="0 0 160 120"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M93.4626 0H23.5665C10.5511 0 0 10.5511 0 23.5665V93.4626C0 106.478 10.5511 117.029 23.5665 117.029H93.4626C106.478 117.029 117.029 106.478 117.029 93.4626V23.5665C117.029 10.5511 106.478 0 93.4626 0Z"
-            fill="url(#paint0_radial_0_9)"
-          />
-          <path
-            d="M94.4529 48.9854C89.7801 42.265 81.9046 38.3798 73.7142 38.9048C70.1965 32.552 63.6861 28.3517 56.0732 27.8792C50.7704 27.5642 45.4151 29.4018 41.2674 32.972C38.4322 35.4396 36.3846 38.2748 35.1245 41.4775C34.3895 43.3676 32.7094 44.5751 30.9243 44.5751H18.3761V55.0757H30.9243C37.0671 55.0757 42.5799 51.243 44.8901 45.3102C45.5201 43.6826 46.5702 42.265 48.1453 40.8999C50.1929 39.1148 52.8705 38.1698 55.3907 38.3273C59.1709 38.5898 61.8485 40.3224 63.5286 42.475C65.3137 44.4701 66.3113 47.5678 66.8888 50.6655C70.249 49.7204 73.9242 48.9329 77.4419 49.5104C80.3296 49.9829 83.0072 51.5055 84.9498 53.7631C85.2648 54.1307 85.5798 54.4982 85.8424 54.9182C88.3625 58.5409 88.835 63.0037 87.1549 67.4139C85.6324 71.5091 80.0145 75.2369 75.3418 75.2369H38.7997C33.8119 75.2369 29.7167 71.5091 29.0867 66.7314H18.5861C19.2686 77.337 28.0366 85.7374 38.7997 85.7374H75.3943C84.4248 85.7374 93.9278 79.3321 97.0255 71.1416C99.9132 63.4762 98.9681 55.3907 94.5054 48.9329L94.4529 48.9854Z"
-            fill="#FFFAE9"
-          />
-          <defs>
-            <radialGradient
-              id="paint0_radial_0_9"
-              cx="0"
-              cy="0"
-              r="1"
-              gradientUnits="userSpaceOnUse"
-              gradientTransform="translate(-28.5 -58) rotate(54.335) scale(209.246)"
-            >
-              <stop stop-color="#40D1FF" />
-              <stop offset="1" stop-color="#0097FF" />
-            </radialGradient>
-          </defs>
-        </svg>
-        <div class="logo-text">
-          <h1>Frappe Cloud</h1>
-        </div>
+    <div class="content">
+      <svg
+        width="40"
+        height="40"
+        viewBox="0 0 40 40"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        <path
+          d="M17.4 5.5a3 3 0 0 1 5.2 0l14.1 24.5a3 3 0 0 1-2.6 4.5H5.9a3 3 0 0 1-2.6-4.5L17.4 5.5Z"
+          stroke="#E5484D"
+          stroke-width="2.5"
+          stroke-linejoin="round"
+        />
+        <path
+          d="M20 15.5v6.5"
+          stroke="#E5484D"
+          stroke-width="2.5"
+          stroke-linecap="round"
+        />
+        <circle cx="20" cy="27.5" r="1.75" fill="#E5484D" />
+      </svg>
+      <div class="text">
+        <h1>This site took too long to respond</h1>
+        <p>Error: 504 Gateway Timeout</p>
       </div>
-      <div class="message-container">
-        <div class="alert-icon">
-          <!-- Red filled circle with white exclamation mark (scaled down via CSS) -->
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
-            <circle cx="12" cy="12" r="10" fill="#EF4444" stroke="#EF4444" />
-            <line x1="12" x2="12" y1="8" y2="12" stroke="white" />
-            <line x1="12" x2="12.01" y1="16" y2="16" stroke="white" />
-          </svg>
-        </div>
-        <h1>Gateway Timeout</h1>
-        <p class="message">
-          Your site appears to be running slow.
-          <a
-            href="https://docs.frappe.io/cloud/site/common-issues/site-slow-504-gateway-timeout"
-            style="
-              display: inline-block;
-              margin-top: 10px;
-              padding: 8px 16px;
-              background: #f5f5f5;
-              border-radius: 4px;
-              color: #333;
-              text-decoration: none;
-              font-weight: bold;
-              border: 1px solid #e0e0e0;
-            "
-          >
-            📄 Follow the step-by-step guide to debug this issue
-          </a>
-        </p>
-        <p>
-          If you are the owner of this site, please check the analytics on your
-          site's
-          <a class="dashboard-url" href="https://frappecloud.com/dashboard"
-            ><strong>dashboard</strong></a
-          >.
-        </p>
-      </div>
+      <a
+        class="button"
+        href="https://docs.frappe.io/cloud/site/common-issues/site-slow-504-gateway-timeout"
+        >View troubleshooting guide</a
+      >
     </div>
+    <p class="footer">
+      Site owner? Review the
+      <a class="dashboard-url" href="https://frappecloud.com/dashboard"
+        >request analytics</a
+      >
+      to find the slow requests.
+    </p>
+    <script>
+      // the dashboard link needs the site name, which only the browser knows here
+      document.querySelector(".dashboard-url").href =
+        `https://frappecloud.com/dashboard/sites/${window.location.hostname}/insights/analytics`;
+    </script>
   </body>
-
-  <script>
-    const dashboardUrl = document.querySelector(".dashboard-url");
-    const siteName = window.location.hostname;
-    dashboardUrl.href = `https://frappecloud.com/dashboard/sites/${siteName}/insights/analytics`;
-  </script>
 </html>

--- a/agent/pages/home.html
+++ b/agent/pages/home.html
@@ -1,115 +1,122 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <title>Frappe Cloud</title>
-        <style>
-            html {
-                -webkit-font-smoothing: antialiased;
-                -moz-osx-font-smoothing: grayscale;
-            }
-            body {
-                font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-                color: #1A4469;
-                background-color: #F9FAFA;
-            }
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Frappe Cloud</title>
+    <style>
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
 
-            .container {
-                padding-top: 4rem;
-                max-width: 768px;
-                margin: 0 auto;
-            }
+      html {
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+        color-scheme: light;
+      }
 
-            .logo {
-                text-align: center;
-                display: flex;
-                justify-content: center;
-                align-items: center;
-            }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
+          Cantarell, "Helvetica Neue", sans-serif;
+        background-color: #ffffff;
+        color: #171717;
+        min-height: 100vh;
+        padding: 24px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 48px;
+      }
 
-            .logo svg {
-                height: 2rem;
-            }
+      .content {
+        max-width: 26rem;
+        text-align: center;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 16px;
+      }
 
-            .logo h1 {
-                font-size: 18px;
-                font-weight: 600;
-                color: #171717;
-            }
+      .text {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
 
-            .message-container {
-                width: 24rem;
-                margin: 0 auto;
-                background-color: white;
-                padding: 2.5rem;
-                margin-top: 1.5rem;
-                -webkit-box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-                box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-                font-size: 13px;
-                text-align: center;
-                border-radius: 0.375rem;
-            }
+      h1 {
+        font-size: 20px;
+        font-weight: 600;
+        line-height: 1.3;
+      }
 
-            .alert-icon svg {
-                height: 2rem;
-                width: 2rem;
-            }
+      p {
+        font-size: 14px;
+        line-height: 1.5;
+        color: #525252;
+      }
 
-            h1 {
-                font-size: 16px;
-                font-weight: 500;
-            }
+      .footer {
+        font-size: 14px;
+        line-height: 1.5;
+        text-align: center;
+        color: #7c7c7c;
+      }
 
-            p {
-                color: #4C5A67;
-                line-height: 1.5;
-            }
+      a {
+        color: #0070cc;
+      }
 
-            a {
-                color: #1579D0;
-                text-decoration: none;
-                border-bottom: 1px solid #1579D0;
-            }
-        </style>
-    </head>
+      /* plain-html visited purple. must not reach .button, whose label is white */
+      a:not(.button):visited {
+        color: #551a8b;
+      }
 
-    <body>
-        <div class="container">
-            <div class="logo">
-                <svg width="40" height="100" viewBox="0 0 160 120" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path
-                        d="M93.4626 0H23.5665C10.5511 0 0 10.5511 0 23.5665V93.4626C0 106.478 10.5511 117.029 23.5665 117.029H93.4626C106.478 117.029 117.029 106.478 117.029 93.4626V23.5665C117.029 10.5511 106.478 0 93.4626 0Z"
-                        fill="url(#paint0_radial_0_9)" />
-                    <path
-                        d="M94.4529 48.9854C89.7801 42.265 81.9046 38.3798 73.7142 38.9048C70.1965 32.552 63.6861 28.3517 56.0732 27.8792C50.7704 27.5642 45.4151 29.4018 41.2674 32.972C38.4322 35.4396 36.3846 38.2748 35.1245 41.4775C34.3895 43.3676 32.7094 44.5751 30.9243 44.5751H18.3761V55.0757H30.9243C37.0671 55.0757 42.5799 51.243 44.8901 45.3102C45.5201 43.6826 46.5702 42.265 48.1453 40.8999C50.1929 39.1148 52.8705 38.1698 55.3907 38.3273C59.1709 38.5898 61.8485 40.3224 63.5286 42.475C65.3137 44.4701 66.3113 47.5678 66.8888 50.6655C70.249 49.7204 73.9242 48.9329 77.4419 49.5104C80.3296 49.9829 83.0072 51.5055 84.9498 53.7631C85.2648 54.1307 85.5798 54.4982 85.8424 54.9182C88.3625 58.5409 88.835 63.0037 87.1549 67.4139C85.6324 71.5091 80.0145 75.2369 75.3418 75.2369H38.7997C33.8119 75.2369 29.7167 71.5091 29.0867 66.7314H18.5861C19.2686 77.337 28.0366 85.7374 38.7997 85.7374H75.3943C84.4248 85.7374 93.9278 79.3321 97.0255 71.1416C99.9132 63.4762 98.9681 55.3907 94.5054 48.9329L94.4529 48.9854Z"
-                        fill="#FFFAE9" />
-                    <defs>
-                        <radialGradient id="paint0_radial_0_9" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse"
-                            gradientTransform="translate(-28.5 -58) rotate(54.335) scale(209.246)">
-                            <stop stop-color="#40D1FF" />
-                            <stop offset="1" stop-color="#0097FF" />
-                        </radialGradient>
-                    </defs>
-                </svg>
-                <div class="logo-text">
-                    <h1>Frappe Cloud</h1>
-                </div>
-            </div>
-            <div class="message-container">
-                <div class="alert-icon">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <path fill-rule="evenodd" clip-rule="evenodd"
-                            d="M4.00288 21.3966C2.47791 21.3966 1.51397 19.7584 2.25456 18.4253L10.2527 4.02871C11.0147 2.65709 12.9873 2.6571 13.7493 4.02872L21.7474 18.4253C22.488 19.7584 21.524 21.3966 19.9991 21.3966H4.00288ZM11.9991 18.4126C12.5688 18.4126 13.0307 17.9507 13.0307 17.381C13.0307 16.8113 12.5688 16.3495 11.9991 16.3495C11.4294 16.3495 10.9675 16.8113 10.9675 17.381C10.9675 17.9507 11.4294 18.4126 11.9991 18.4126ZM13 8.8601C13 8.30782 12.5523 7.8601 12 7.8601C11.4477 7.8601 11 8.30782 11 8.8601V13.9074C11 14.4597 11.4477 14.9074 12 14.9074C12.5523 14.9074 13 14.4597 13 13.9074V8.8601Z"
-                            fill="#D6932E" />
-                    </svg>
-                </div>
-                <h1>
-                    Are you lost?
-                </h1>
-                <p class="message">
-                    Why don't you start over from <a href="https://frappecloud.com">Frappe Cloud</a>.
-                </p>
-            </div>
-        </div>
-    </body>
+      .button {
+        display: inline-flex;
+        align-items: center;
+        padding: 8px 12px;
+        border-radius: 8px;
+        background-color: #171717;
+        color: #ffffff;
+        font-size: 14px;
+        text-decoration: none;
+      }
+
+      .button:hover {
+        background-color: #2f2f2f;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="content">
+      <svg
+        width="40"
+        height="40"
+        viewBox="0 0 40 40"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        <circle cx="20" cy="20" r="16.5" stroke="#737373" stroke-width="2.5" />
+        <path
+          d="M16.4 16.1a3.6 3.6 0 1 1 5 3.4c-.9.4-1.4 1.2-1.4 2.1v.7"
+          stroke="#737373"
+          stroke-width="2.5"
+          stroke-linecap="round"
+        />
+        <circle cx="20" cy="26.5" r="1.75" fill="#737373" />
+      </svg>
+      <div class="text">
+        <h1>Are you lost?</h1>
+        <p>This address does not point to a site on Frappe Cloud.</p>
+      </div>
+      <a class="button" href="https://frappecloud.com">Go to Frappe Cloud</a>
+    </div>
+  </body>
 </html>

--- a/agent/pages/internal_server_error.html
+++ b/agent/pages/internal_server_error.html
@@ -129,15 +129,11 @@
     </div>
     <p class="footer">
       Site owner? Review the
-      <a class="dashboard-url" href="https://frappecloud.com/dashboard"
+      <a
+        href="https://frappecloud.com/dashboard/benches/__BENCH_NAME__/logs/web.error.log"
         >error logs</a
       >
       to identify the cause.
     </p>
-    <script>
-      // the dashboard link needs the site name, which only the browser knows here
-      document.querySelector(".dashboard-url").href =
-        `https://frappecloud.com/dashboard/sites/${window.location.hostname}`;
-    </script>
   </body>
 </html>

--- a/agent/pages/internal_server_error.html
+++ b/agent/pages/internal_server_error.html
@@ -2,169 +2,142 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Internal Server Error</title>
     <style>
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
       html {
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
+        color-scheme: light;
       }
+
       body {
         font-family:
           -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
-          Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
-        color: #1a4469;
-        background-color: #f9fafa;
+          Cantarell, "Helvetica Neue", sans-serif;
+        background-color: #ffffff;
+        color: #171717;
+        min-height: 100vh;
+        padding: 24px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 48px;
       }
 
-      .container {
-        padding-top: 4rem;
-        max-width: 768px;
-        margin: 0 auto;
-      }
-
-      .logo {
+      .content {
+        max-width: 26rem;
         text-align: center;
         display: flex;
-        justify-content: center;
+        flex-direction: column;
         align-items: center;
+        gap: 16px;
       }
 
-      .logo svg {
-        height: 2rem;
-      }
-
-      .logo h1 {
-        font-size: 18px;
-        font-weight: 600;
-        color: #171717;
-      }
-
-      .message-container {
-        width: 24rem;
-        margin: 0 auto;
-        background-color: white;
-        padding: 2.5rem;
-        margin-top: 1.5rem;
-        -webkit-box-shadow:
-          0 4px 6px -1px rgba(0, 0, 0, 0.1),
-          0 2px 4px -1px rgba(0, 0, 0, 0.06);
-        box-shadow:
-          0 4px 6px -1px rgba(0, 0, 0, 0.1),
-          0 2px 4px -1px rgba(0, 0, 0, 0.06);
-        font-size: 13px;
-        text-align: center;
-        border-radius: 0.375rem;
-      }
-
-      .alert-icon svg {
-        height: 2rem;
-        width: 2rem;
+      .text {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
       }
 
       h1 {
-        font-size: 16px;
-        font-weight: 500;
+        font-size: 20px;
+        font-weight: 600;
+        line-height: 1.3;
       }
 
       p {
-        color: #4c5a67;
+        font-size: 14px;
         line-height: 1.5;
+        color: #525252;
+      }
+
+      .footer {
+        font-size: 14px;
+        line-height: 1.5;
+        text-align: center;
+        color: #7c7c7c;
       }
 
       a {
-        color: #1579d0;
+        color: #0070cc;
+      }
+
+      /* plain-html visited purple. must not reach .button, whose label is white */
+      a:not(.button):visited {
+        color: #551a8b;
+      }
+
+      .button {
+        display: inline-flex;
+        align-items: center;
+        padding: 8px 12px;
+        border-radius: 8px;
+        background-color: #171717;
+        color: #ffffff;
+        font-size: 14px;
         text-decoration: none;
-        border-bottom: 1px solid #1579d0;
+      }
+
+      .button:hover {
+        background-color: #2f2f2f;
       }
     </style>
   </head>
-
   <body>
-    <div class="container">
-      <div class="logo">
-        <svg
-          width="40"
-          height="100"
-          viewBox="0 0 160 120"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M93.4626 0H23.5665C10.5511 0 0 10.5511 0 23.5665V93.4626C0 106.478 10.5511 117.029 23.5665 117.029H93.4626C106.478 117.029 117.029 106.478 117.029 93.4626V23.5665C117.029 10.5511 106.478 0 93.4626 0Z"
-            fill="url(#paint0_radial_0_9)"
-          />
-          <path
-            d="M94.4529 48.9854C89.7801 42.265 81.9046 38.3798 73.7142 38.9048C70.1965 32.552 63.6861 28.3517 56.0732 27.8792C50.7704 27.5642 45.4151 29.4018 41.2674 32.972C38.4322 35.4396 36.3846 38.2748 35.1245 41.4775C34.3895 43.3676 32.7094 44.5751 30.9243 44.5751H18.3761V55.0757H30.9243C37.0671 55.0757 42.5799 51.243 44.8901 45.3102C45.5201 43.6826 46.5702 42.265 48.1453 40.8999C50.1929 39.1148 52.8705 38.1698 55.3907 38.3273C59.1709 38.5898 61.8485 40.3224 63.5286 42.475C65.3137 44.4701 66.3113 47.5678 66.8888 50.6655C70.249 49.7204 73.9242 48.9329 77.4419 49.5104C80.3296 49.9829 83.0072 51.5055 84.9498 53.7631C85.2648 54.1307 85.5798 54.4982 85.8424 54.9182C88.3625 58.5409 88.835 63.0037 87.1549 67.4139C85.6324 71.5091 80.0145 75.2369 75.3418 75.2369H38.7997C33.8119 75.2369 29.7167 71.5091 29.0867 66.7314H18.5861C19.2686 77.337 28.0366 85.7374 38.7997 85.7374H75.3943C84.4248 85.7374 93.9278 79.3321 97.0255 71.1416C99.9132 63.4762 98.9681 55.3907 94.5054 48.9329L94.4529 48.9854Z"
-            fill="#FFFAE9"
-          />
-          <defs>
-            <radialGradient
-              id="paint0_radial_0_9"
-              cx="0"
-              cy="0"
-              r="1"
-              gradientUnits="userSpaceOnUse"
-              gradientTransform="translate(-28.5 -58) rotate(54.335) scale(209.246)"
-            >
-              <stop stop-color="#40D1FF" />
-              <stop offset="1" stop-color="#0097FF" />
-            </radialGradient>
-          </defs>
-        </svg>
-        <div class="logo-text">
-          <h1>Frappe Cloud</h1>
-        </div>
+    <div class="content">
+      <svg
+        width="40"
+        height="40"
+        viewBox="0 0 40 40"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        <path
+          d="M17.4 5.5a3 3 0 0 1 5.2 0l14.1 24.5a3 3 0 0 1-2.6 4.5H5.9a3 3 0 0 1-2.6-4.5L17.4 5.5Z"
+          stroke="#E5484D"
+          stroke-width="2.5"
+          stroke-linejoin="round"
+        />
+        <path
+          d="M20 15.5v6.5"
+          stroke="#E5484D"
+          stroke-width="2.5"
+          stroke-linecap="round"
+        />
+        <circle cx="20" cy="27.5" r="1.75" fill="#E5484D" />
+      </svg>
+      <div class="text">
+        <h1>The application returned an error</h1>
+        <p>Error: 500 Internal Server Error</p>
       </div>
-      <div class="message-container">
-        <div class="alert-icon">
-          <!-- Red filled circle with white exclamation mark (scaled down via CSS) -->
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
-            <circle cx="12" cy="12" r="10" fill="#EF4444" stroke="#EF4444" />
-            <line x1="12" x2="12" y1="8" y2="12" stroke="white" />
-            <line x1="12" x2="12.01" y1="16" y2="16" stroke="white" />
-          </svg>
-        </div>
-        <h1>Internal Server Error</h1>
-        <p class="message">
-          There seems to be an error in your application.
-          <a
-            href="https://docs.frappe.io/cloud/site/common-issues/500-internal-server-error"
-            style="
-              display: inline-block;
-              margin-top: 10px;
-              padding: 8px 16px;
-              background: #f5f5f5;
-              border-radius: 4px;
-              color: #333;
-              text-decoration: none;
-              font-weight: bold;
-              border: 1px solid #e0e0e0;
-            "
-          >
-            📄 Follow the step-by-step guide to debug this issue
-          </a>
-        </p>
-        <p>
-          If you are the owner of this site, please check the error logs on your
-          site's
-          <a class="dashboard-url" href="https://frappecloud.com/dashboard"
-            ><strong>dashboard</strong></a
-          >.
-        </p>
-      </div>
+      <a
+        class="button"
+        href="https://docs.frappe.io/cloud/performance-error-debugging#500-internal-server-error"
+        >View troubleshooting guide</a
+      >
     </div>
+    <p class="footer">
+      Site owner? Review the
+      <a class="dashboard-url" href="https://frappecloud.com/dashboard"
+        >error logs</a
+      >
+      to identify the cause.
+    </p>
+    <script>
+      // the dashboard link needs the site name, which only the browser knows here
+      document.querySelector(".dashboard-url").href =
+        `https://frappecloud.com/dashboard/sites/${window.location.hostname}`;
+    </script>
   </body>
-
-  <script>
-    const dashboardUrl = document.querySelector(".dashboard-url");
-    const siteName = window.location.hostname;
-    dashboardUrl.href = `https://frappecloud.com/dashboard/sites/${siteName}`;
-  </script>
 </html>

--- a/agent/pages/suspended.html
+++ b/agent/pages/suspended.html
@@ -1,122 +1,135 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <title>This Site is Suspended</title>
-        <style>
-            html {
-                -webkit-font-smoothing: antialiased;
-                -moz-osx-font-smoothing: grayscale;
-            }
-            body {
-                font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-                color: #1A4469;
-                background-color: #F9FAFA;
-            }
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>This Site is Suspended</title>
+    <style>
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
 
-            .container {
-                padding-top: 4rem;
-                max-width: 768px;
-                margin: 0 auto;
-            }
+      html {
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+        color-scheme: light;
+      }
 
-            .logo {
-                text-align: center;
-                display: flex;
-                justify-content: center;
-                align-items: center;
-            }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
+          Cantarell, "Helvetica Neue", sans-serif;
+        background-color: #ffffff;
+        color: #171717;
+        min-height: 100vh;
+        padding: 24px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 48px;
+      }
 
-            .logo svg {
-                height: 2rem;
-            }
+      .content {
+        max-width: 26rem;
+        text-align: center;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 16px;
+      }
 
-            .logo h1 {
-                font-size: 18px;
-                font-weight: 600;
-                color: #171717;
-            }
+      .text {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
 
-            .message-container {
-                width: 24rem;
-                margin: 0 auto;
-                background-color: white;
-                padding: 2.5rem;
-                margin-top: 1.5rem;
-                -webkit-box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-                box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-                font-size: 13px;
-                text-align: center;
-                border-radius: 0.375rem;
-            }
+      h1 {
+        font-size: 20px;
+        font-weight: 600;
+        line-height: 1.3;
+      }
 
-            .alert-icon svg {
-                height: 2rem;
-                width: 2rem;
-            }
+      p {
+        font-size: 14px;
+        line-height: 1.5;
+        color: #525252;
+      }
 
-            h1 {
-                font-size: 16px;
-                font-weight: 500;
-            }
+      .footer {
+        font-size: 14px;
+        line-height: 1.5;
+        text-align: center;
+        color: #7c7c7c;
+      }
 
-            p {
-                color: #4C5A67;
-                line-height: 1.5;
-            }
+      a {
+        color: #0070cc;
+      }
 
-            a {
-                color: #1579D0;
-                text-decoration: none;
-                border-bottom: 1px solid #1579D0;
-            }
-        </style>
-    </head>
+      /* plain-html visited purple. must not reach .button, whose label is white */
+      a:not(.button):visited {
+        color: #551a8b;
+      }
 
-    <body>
-        <div class="container">
-            <div class="logo">
-                <svg width="40" height="100" viewBox="0 0 160 120" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path
-                        d="M93.4626 0H23.5665C10.5511 0 0 10.5511 0 23.5665V93.4626C0 106.478 10.5511 117.029 23.5665 117.029H93.4626C106.478 117.029 117.029 106.478 117.029 93.4626V23.5665C117.029 10.5511 106.478 0 93.4626 0Z"
-                        fill="url(#paint0_radial_0_9)" />
-                    <path
-                        d="M94.4529 48.9854C89.7801 42.265 81.9046 38.3798 73.7142 38.9048C70.1965 32.552 63.6861 28.3517 56.0732 27.8792C50.7704 27.5642 45.4151 29.4018 41.2674 32.972C38.4322 35.4396 36.3846 38.2748 35.1245 41.4775C34.3895 43.3676 32.7094 44.5751 30.9243 44.5751H18.3761V55.0757H30.9243C37.0671 55.0757 42.5799 51.243 44.8901 45.3102C45.5201 43.6826 46.5702 42.265 48.1453 40.8999C50.1929 39.1148 52.8705 38.1698 55.3907 38.3273C59.1709 38.5898 61.8485 40.3224 63.5286 42.475C65.3137 44.4701 66.3113 47.5678 66.8888 50.6655C70.249 49.7204 73.9242 48.9329 77.4419 49.5104C80.3296 49.9829 83.0072 51.5055 84.9498 53.7631C85.2648 54.1307 85.5798 54.4982 85.8424 54.9182C88.3625 58.5409 88.835 63.0037 87.1549 67.4139C85.6324 71.5091 80.0145 75.2369 75.3418 75.2369H38.7997C33.8119 75.2369 29.7167 71.5091 29.0867 66.7314H18.5861C19.2686 77.337 28.0366 85.7374 38.7997 85.7374H75.3943C84.4248 85.7374 93.9278 79.3321 97.0255 71.1416C99.9132 63.4762 98.9681 55.3907 94.5054 48.9329L94.4529 48.9854Z"
-                        fill="#FFFAE9" />
-                    <defs>
-                        <radialGradient id="paint0_radial_0_9" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse"
-                            gradientTransform="translate(-28.5 -58) rotate(54.335) scale(209.246)">
-                            <stop stop-color="#40D1FF" />
-                            <stop offset="1" stop-color="#0097FF" />
-                        </radialGradient>
-                    </defs>
-                </svg>
-                <div class="logo-text">
-                    <h1>Frappe Cloud</h1>
-                </div>
-            </div>
-            <div class="message-container">
-                <div class="alert-icon">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <path fill-rule="evenodd" clip-rule="evenodd"
-                            d="M4.00288 21.3966C2.47791 21.3966 1.51397 19.7584 2.25456 18.4253L10.2527 4.02871C11.0147 2.65709 12.9873 2.6571 13.7493 4.02872L21.7474 18.4253C22.488 19.7584 21.524 21.3966 19.9991 21.3966H4.00288ZM11.9991 18.4126C12.5688 18.4126 13.0307 17.9507 13.0307 17.381C13.0307 16.8113 12.5688 16.3495 11.9991 16.3495C11.4294 16.3495 10.9675 16.8113 10.9675 17.381C10.9675 17.9507 11.4294 18.4126 11.9991 18.4126ZM13 8.8601C13 8.30782 12.5523 7.8601 12 7.8601C11.4477 7.8601 11 8.30782 11 8.8601V13.9074C11 14.4597 11.4477 14.9074 12 14.9074C12.5523 14.9074 13 14.4597 13 13.9074V8.8601Z"
-                            fill="#D6932E" />
-                    </svg>
-                </div>
-                <h1>
-                    This Site is Suspended.
-                </h1>
-                <p class="message">
-                    This site has been suspended due to exceeding site limits or a payment failure. If you are the owner
-                    of this site, resolve issues related to your site's plan from the <a class="dashboard-url" href="https://frappecloud.com/dashboard">Frappe Cloud Dashboard</a>.
-                </p>
-            </div>
-        </div>
-    </body>
+      .button {
+        display: inline-flex;
+        align-items: center;
+        padding: 8px 12px;
+        border-radius: 8px;
+        background-color: #171717;
+        color: #ffffff;
+        font-size: 14px;
+        text-decoration: none;
+      }
 
+      .button:hover {
+        background-color: #2f2f2f;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="content">
+      <svg
+        width="40"
+        height="40"
+        viewBox="0 0 40 40"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        <circle cx="20" cy="20" r="16.5" stroke="#E79913" stroke-width="2.5" />
+        <path
+          d="M20 12v9"
+          stroke="#E79913"
+          stroke-width="2.5"
+          stroke-linecap="round"
+        />
+        <circle cx="20" cy="26.5" r="1.75" fill="#E79913" />
+      </svg>
+      <div class="text">
+        <h1>This site is temporarily unavailable</h1>
+        <p>
+          The site has been suspended because of exceeded plan limits or a
+          payment failure.
+        </p>
+      </div>
+    </div>
+    <p class="footer">
+      Site owner? Resolve the issues with your plan from the
+      <a class="dashboard-url" href="https://frappecloud.com/dashboard"
+        >dashboard</a
+      >.
+    </p>
     <script>
-        const dashboardUrl = document.querySelector('.dashboard-url');
-        const siteName = window.location.hostname;
-        dashboardUrl.href = `https://frappecloud.com/dashboard/sites/${siteName}`;
+      // the dashboard link needs the site name, which only the browser knows here
+      document.querySelector(".dashboard-url").href =
+        `https://frappecloud.com/dashboard/sites/${window.location.hostname}`;
     </script>
+  </body>
 </html>

--- a/agent/pages/suspended_saas.html
+++ b/agent/pages/suspended_saas.html
@@ -1,88 +1,128 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <title>This Site is Suspended</title>
-        <style>
-            html {
-                -webkit-font-smoothing: antialiased;
-                -moz-osx-font-smoothing: grayscale;
-            }
-            body {
-                font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-                color: #1A4469;
-                background-color: #F9FAFA;
-            }
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>This Site is Suspended</title>
+    <style>
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
 
-            .container {
-                padding-top: 4rem;
-                max-width: 768px;
-                margin: 0 auto;
-            }
+      html {
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+        color-scheme: light;
+      }
 
-            .logo {
-                text-align: center;
-            }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
+          Cantarell, "Helvetica Neue", sans-serif;
+        background-color: #ffffff;
+        color: #171717;
+        min-height: 100vh;
+        padding: 24px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 48px;
+      }
 
-            .logo svg {
-                height: 1rem;
-            }
+      .content {
+        max-width: 26rem;
+        text-align: center;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 16px;
+      }
 
-            .message-container {
-                width: 24rem;
-                margin: 0 auto;
-                background-color: white;
-                padding: 2.5rem;
-                margin-top: 1.5rem;
-                -webkit-box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-                box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-                font-size: 13px;
-                text-align: center;
-                border-radius: 0.375rem;
-            }
+      .text {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
 
-            .alert-icon svg {
-                height: 2rem;
-                width: 2rem;
-            }
+      h1 {
+        font-size: 20px;
+        font-weight: 600;
+        line-height: 1.3;
+      }
 
-            h1 {
-                font-size: 16px;
-                font-weight: 500;
-            }
+      p {
+        font-size: 14px;
+        line-height: 1.5;
+        color: #525252;
+      }
 
-            p {
-                color: #4C5A67;
-                line-height: 1.5;
-            }
+      .footer {
+        font-size: 14px;
+        line-height: 1.5;
+        text-align: center;
+        color: #7c7c7c;
+      }
 
-            a {
-                color: #1579D0;
-                text-decoration: none;
-                border-bottom: 1px solid #1579D0;
-            }
-        </style>
-    </head>
+      a {
+        color: #0070cc;
+      }
 
-    <body>
-        <div class="container">
-            <div class="message-container">
-                <div class="alert-icon">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <path fill-rule="evenodd" clip-rule="evenodd"
-                            d="M4.00288 21.3966C2.47791 21.3966 1.51397 19.7584 2.25456 18.4253L10.2527 4.02871C11.0147 2.65709 12.9873 2.6571 13.7493 4.02872L21.7474 18.4253C22.488 19.7584 21.524 21.3966 19.9991 21.3966H4.00288ZM11.9991 18.4126C12.5688 18.4126 13.0307 17.9507 13.0307 17.381C13.0307 16.8113 12.5688 16.3495 11.9991 16.3495C11.4294 16.3495 10.9675 16.8113 10.9675 17.381C10.9675 17.9507 11.4294 18.4126 11.9991 18.4126ZM13 8.8601C13 8.30782 12.5523 7.8601 12 7.8601C11.4477 7.8601 11 8.30782 11 8.8601V13.9074C11 14.4597 11.4477 14.9074 12 14.9074C12.5523 14.9074 13 14.4597 13 13.9074V8.8601Z"
-                            fill="#D6932E" />
-                    </svg>
-                </div>
-                <h1>
-                    This Site is Suspended.
-                </h1>
-                <p class="message">
-                    This site has been suspended due to exceeding site limits or a payment failure. If you are the owner
-                    of this site, resolve issues related to your site's plan from the <a href="https://frappecloud.com/dashboard/saas/login">Dashboard</a>.
-                </p>
-            </div>
-        </div>
-    </body>
+      /* plain-html visited purple. must not reach .button, whose label is white */
+      a:not(.button):visited {
+        color: #551a8b;
+      }
+
+      .button {
+        display: inline-flex;
+        align-items: center;
+        padding: 8px 12px;
+        border-radius: 8px;
+        background-color: #171717;
+        color: #ffffff;
+        font-size: 14px;
+        text-decoration: none;
+      }
+
+      .button:hover {
+        background-color: #2f2f2f;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="content">
+      <svg
+        width="40"
+        height="40"
+        viewBox="0 0 40 40"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        <circle cx="20" cy="20" r="16.5" stroke="#E79913" stroke-width="2.5" />
+        <path
+          d="M20 12v9"
+          stroke="#E79913"
+          stroke-width="2.5"
+          stroke-linecap="round"
+        />
+        <circle cx="20" cy="26.5" r="1.75" fill="#E79913" />
+      </svg>
+      <div class="text">
+        <h1>This site is temporarily unavailable</h1>
+        <p>
+          The site has been suspended because of exceeded plan limits or a
+          payment failure.
+        </p>
+      </div>
+    </div>
+    <p class="footer">
+      Site owner? Resolve the issues with your plan from the
+      <a href="https://frappecloud.com/dashboard/saas/login">dashboard</a>.
+    </p>
+  </body>
 </html>
-

--- a/agent/templates/bench/nginx.conf.jinja2
+++ b/agent/templates/bench/nginx.conf.jinja2
@@ -178,6 +178,9 @@ server {
 
 	location = /internal_server_error.html {
 		root {{ error_pages_directory }};
+		# one static page is shared by every bench on the server, so the link to this
+		# bench's web.error.log can only be completed here
+		sub_filter '__BENCH_NAME__' '{{ bench_name }}';
 	}
 
 	proxy_intercept_errors on;
@@ -346,6 +349,9 @@ server {
 
 	location = /internal_server_error.html {
 		root {{ error_pages_directory }};
+		# one static page is shared by every bench on the server, so the link to this
+		# bench's web.error.log can only be completed here
+		sub_filter '__BENCH_NAME__' '{{ bench_name }}';
 	}
 
 	# optimizations

--- a/agent/tests/test_pages.py
+++ b/agent/tests/test_pages.py
@@ -5,6 +5,9 @@ import os
 import unittest
 
 PAGES_DIRECTORY = os.path.join(os.path.dirname(__file__), "..", "pages")
+BENCH_NGINX_TEMPLATE = os.path.join(
+    os.path.dirname(__file__), "..", "templates", "bench", "nginx.conf.jinja2"
+)
 
 
 def read_pages():
@@ -33,3 +36,16 @@ class TestPages(unittest.TestCase):
         for name, html in read_pages():
             if "dashboard-url" in html:
                 self.assertIn("dashboard/sites/${window.location.hostname}", html, name)
+
+    def test_bench_name_placeholder_is_substituted_by_nginx(self):
+        # an unsubstituted __BENCH_NAME__ ships a dead link to the site owner
+        with open(BENCH_NGINX_TEMPLATE) as f:
+            template = f.read()
+
+        substituted = "sub_filter '__BENCH_NAME__' '{{ bench_name }}';"
+        for name, html in read_pages():
+            if "__BENCH_NAME__" not in html:
+                continue
+            page_locations = template.count(f"location = /{name} {{")
+            self.assertTrue(page_locations, f"{name} is not served by the bench nginx config")
+            self.assertEqual(template.count(substituted), page_locations, name)

--- a/agent/tests/test_pages.py
+++ b/agent/tests/test_pages.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import glob
+import os
+import unittest
+
+PAGES_DIRECTORY = os.path.join(os.path.dirname(__file__), "..", "pages")
+
+
+def read_pages():
+    for path in sorted(glob.glob(os.path.join(PAGES_DIRECTORY, "*.html"))):
+        with open(path) as f:
+            yield os.path.basename(path), f.read()
+
+
+class TestPages(unittest.TestCase):
+    """The error pages are served by nginx when the site is already broken."""
+
+    def test_pages_are_self_contained(self):
+        # an external font or stylesheet would hang on the very networks these pages appear on
+        for name, html in read_pages():
+            self.assertNotIn("<link", html, name)
+            self.assertNotIn('src="http', html, name)
+
+    def test_visited_links_are_marked_but_never_the_button(self):
+        # a bare a:visited outranks .button's own colour and repaints its white label purple
+        for name, html in read_pages():
+            self.assertIn("a:not(.button):visited", html, name)
+            self.assertNotIn(".button:visited", html, name)
+
+    def test_placeholder_dashboard_links_are_rewritten(self):
+        # the link ships pointing at the dashboard root; only the script knows the site name
+        for name, html in read_pages():
+            if "dashboard-url" in html:
+                self.assertIn("dashboard/sites/${window.location.hostname}", html, name)


### PR DESCRIPTION
## What

Redesigns all eight error pages and points the 500 page at the bench's `web.error.log`.

Before, each page was a logo header over a shadowed card, with the docs link styled as an inline `📄` pseudo-button. Now every page is one shared layout: icon, heading, error line, optional docs button, owner footer.

| Page | Status | Icon |
|---|---|---|
| `bad_gateway.html` | 502 | red |
| `gateway_timeout.html` | 504 | red |
| `internal_server_error.html` | 500 | red |
| `exceeded.html` | 429 | amber |
| `suspended.html` / `suspended_saas.html` | 402 | amber |
| `deactivated.html` | 503 | amber |
| `home.html` | — | neutral |

## Visited links

Text links carry the plain-html visited purple. The rule is scoped `a:not(.button):visited` deliberately: a bare `a:visited` has specificity (0,1,1) and outranks `.button`'s own `color: #fff` at (0,1,0), which repaints the button's white label purple. The button itself has no visited state — `:visited` reaches only a few colour properties, never a button's label, and Chrome has partitioned it per top-level site and frame origin since 136.

## The 500 page

The traceback for a 500 lands in the bench's `web.error.log`, so the footer now links straight to `/dashboard/benches/<bench>/logs/web.error.log` instead of the site's dashboard root.

One static page is shared by every bench on the server, so the page ships `__BENCH_NAME__` and the per-bench nginx config substitutes it:

```nginx
location = /internal_server_error.html {
	root {{ error_pages_directory }};
	sub_filter '__BENCH_NAME__' '{{ bench_name }}';
}
```

This works because the 500 interception injects `<iframe src="/internal_server_error.html">` — a relative URL — so the iframe request carries the failing site's `Host` and resolves through its own bench's server block.

A side effect worth having: this page no longer needs the `window.location.hostname` script, making it the one error page immune to the custom-domain problem, where `hostname` is not the site's name once a custom domain is in front of it. The other pages still have that pre-existing issue.

Also drops the Google Fonts `<link>` an earlier attempt carried — an external font request would hang on the very networks these pages appear on.

## Testing

Verified end to end against a local Frappe Cloud install with a real bench on `f1.local.frappe.dev`:

- nginx substitution over HTTP — the same file (one md5) served through two hosts returned `bench-0004-000023-f1` and `bench-0004-000022-f1` respectively
- `press.api.bench.log` returned `{'web.error.log': ...}` through the full path: permission check, release-group check, circuit breaker, live agent call
- `LogPage.vue` derives the release group as `bench-${name.split('-')[1]}`; confirmed against real records (`bench-0004-000023-f1` → `bench-0004`)
- both template branches (standalone and non-standalone) render the `sub_filter` correctly

`agent/tests/test_pages.py` covers the invariants that would silently break a page: no external resources, the scoped visited rule, dashboard links paired with their rewrite script, and every `__BENCH_NAME__` matched by a `sub_filter` in each of its nginx location blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)