### PR TITLE
fix(pages): Let the 500 page's links escape their iframe

### DIFF
--- a/agent/pages/internal_server_error.html
+++ b/agent/pages/internal_server_error.html
@@ -121,8 +121,12 @@
         <h1>The application returned an error</h1>
         <p>Error: 500 Internal Server Error</p>
       </div>
+      <!-- nginx serves this page inside an iframe, so links need _top to escape
+           it. Both targets send X-Frame-Options: SAMEORIGIN and would otherwise
+           refuse to render. -->
       <a
         class="button"
+        target="_top"
         href="https://docs.frappe.io/cloud/performance-error-debugging#500-internal-server-error"
         >View troubleshooting guide</a
       >
@@ -130,6 +134,7 @@
     <p class="footer">
       Site owner? Review the
       <a
+        target="_top"
         href="https://frappecloud.com/dashboard/benches/__BENCH_NAME__/logs/web.error.log"
         >error logs</a
       >

--- a/agent/pages/internal_server_error.html
+++ b/agent/pages/internal_server_error.html
@@ -121,12 +121,13 @@
         <h1>The application returned an error</h1>
         <p>Error: 500 Internal Server Error</p>
       </div>
-      <!-- nginx serves this page inside an iframe, so links need _top to escape
-           it. Both targets send X-Frame-Options: SAMEORIGIN and would otherwise
-           refuse to render. -->
+      <!-- nginx serves this page inside an iframe. A link with no target loads
+           into that frame, and both destinations send X-Frame-Options:
+           SAMEORIGIN, so the browser refuses to render them. _blank opens a new
+           top-level tab, which is never framed, and leaves this page up. -->
       <a
         class="button"
-        target="_top"
+        target="_blank"
         href="https://docs.frappe.io/cloud/performance-error-debugging#500-internal-server-error"
         >View troubleshooting guide</a
       >
@@ -134,7 +135,7 @@
     <p class="footer">
       Site owner? Review the
       <a
-        target="_top"
+        target="_blank"
         href="https://frappecloud.com/dashboard/benches/__BENCH_NAME__/logs/web.error.log"
         >error logs</a
       >

--- a/agent/tests/test_pages.py
+++ b/agent/tests/test_pages.py
@@ -39,8 +39,9 @@ class TestPages(unittest.TestCase):
                 self.assertIn("dashboard/sites/${window.location.hostname}", html, name)
 
     def test_iframed_pages_escape_the_frame(self):
-        # nginx injects the 500 page as an iframe. Without _top a link loads inside
-        # that frame, and both destinations send X-Frame-Options: SAMEORIGIN.
+        # nginx injects the 500 page as an iframe. A link with no target loads into
+        # that frame, and every destination sends X-Frame-Options: SAMEORIGIN.
+        escaping_targets = ('target="_blank"', 'target="_top"')
         with open(BENCH_NGINX_TEMPLATE) as f:
             template = f.read()
 
@@ -49,7 +50,8 @@ class TestPages(unittest.TestCase):
                 continue
             for tag in re.findall(r"<a\b[^>]*>", html):
                 if 'href="http' in tag:
-                    self.assertIn('target="_top"', tag, f"{name}: {tag}")
+                    escapes = any(target in tag for target in escaping_targets)
+                    self.assertTrue(escapes, f"{name}: {tag}")
 
     def test_bench_name_placeholder_is_substituted_by_nginx(self):
         # an unsubstituted __BENCH_NAME__ ships a dead link to the site owner

--- a/agent/tests/test_pages.py
+++ b/agent/tests/test_pages.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import glob
 import os
+import re
 import unittest
 
 PAGES_DIRECTORY = os.path.join(os.path.dirname(__file__), "..", "pages")
@@ -36,6 +37,19 @@ class TestPages(unittest.TestCase):
         for name, html in read_pages():
             if "dashboard-url" in html:
                 self.assertIn("dashboard/sites/${window.location.hostname}", html, name)
+
+    def test_iframed_pages_escape_the_frame(self):
+        # nginx injects the 500 page as an iframe. Without _top a link loads inside
+        # that frame, and both destinations send X-Frame-Options: SAMEORIGIN.
+        with open(BENCH_NGINX_TEMPLATE) as f:
+            template = f.read()
+
+        for name, html in read_pages():
+            if f'iframe src="/{name}"' not in template:
+                continue
+            for tag in re.findall(r"<a\b[^>]*>", html):
+                if 'href="http' in tag:
+                    self.assertIn('target="_top"', tag, f"{name}: {tag}")
 
     def test_bench_name_placeholder_is_substituted_by_nginx(self):
         # an unsubstituted __BENCH_NAME__ ships a dead link to the site owner


### PR DESCRIPTION
## Problem

Both links on the 500 page are dead in the browser. Clicking either one shows a browser security page instead of the destination:

> Firefox Can't Open This Page — To protect your security, docs.frappe.io will not allow Firefox to display the page if another site has embedded it.

nginx does not serve this page directly. It injects it through `sub_filter` as a frame:

```nginx
map $upstream_status $internal_server_error_page_... {
    500     '<style>...</style><iframe src="/internal_server_error.html"></iframe><div hidden>';
```

An anchor with no `target` navigates the frame it lives in, so the destination is asked to render inside that iframe. Both destinations refuse:

```
$ curl -sI https://docs.frappe.io/cloud/performance-error-debugging | grep -i x-frame
x-frame-options: SAMEORIGIN
$ curl -sI https://frappecloud.com/dashboard/ | grep -i x-frame
x-frame-options: SAMEORIGIN
```

This is live on `develop` and affects both the troubleshooting guide button and the `web.error.log` link added in #581.

## Fix

`target="_blank"` on both anchors. A new top-level tab is never framed, so `X-Frame-Options` does not apply to it.

`_top` would also have worked, but it replaces the error page. `_blank` leaves it on screen, which keeps the visited-link colour visible — useful when someone attaches a screenshot to a support ticket and we want to see whether they already opened the guide.

## Test

`test_iframed_pages_escape_the_frame` reads the nginx template, finds which pages get wrapped in an iframe, and requires every external link on those pages to carry a target that escapes the frame (`_blank` or `_top`). Checked against the pre-fix page, it flags both anchors, so it fails without this change rather than passing vacuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
