### PR TITLE
fix(pages): Point the 500 page at the right docs URL

### DIFF
--- a/agent/pages/internal_server_error.html
+++ b/agent/pages/internal_server_error.html
@@ -128,7 +128,7 @@
       <a
         class="button"
         target="_blank"
-        href="https://docs.frappe.io/cloud/performance-error-debugging#500-internal-server-error"
+        href="https://docs.frappe.io/cloud/site/common-issues/500-internal-server-error"
         >View troubleshooting guide</a
       >
     </div>


### PR DESCRIPTION
The 500 error page linked to `performance-error-debugging#500-internal-server-error`, which is not the page for this error. Points it at `site/common-issues/500-internal-server-error`, matching the 502 and 504 pages, whose links were already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)