### PR TITLE
fix(nginx): Intercept 502 and 504 on the app server only

### DIFF
--- a/agent/pages/server_timeout.html
+++ b/agent/pages/server_timeout.html
@@ -1,0 +1,145 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Server Timeout</title>
+    <style>
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      html {
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+        color-scheme: light;
+      }
+
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
+          Cantarell, "Helvetica Neue", sans-serif;
+        background-color: #ffffff;
+        color: #171717;
+        min-height: 100vh;
+        padding: 24px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 48px;
+      }
+
+      .content {
+        max-width: 26rem;
+        text-align: center;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 16px;
+      }
+
+      .text {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      h1 {
+        font-size: 20px;
+        font-weight: 600;
+        line-height: 1.3;
+      }
+
+      p {
+        font-size: 14px;
+        line-height: 1.5;
+        color: #525252;
+      }
+
+      .footer {
+        font-size: 14px;
+        line-height: 1.5;
+        text-align: center;
+        color: #7c7c7c;
+      }
+
+      a {
+        color: #0070cc;
+      }
+
+      /* plain-html visited purple. must not reach .button, whose label is white */
+      a:not(.button):visited {
+        color: #551a8b;
+      }
+
+      .button {
+        display: inline-flex;
+        align-items: center;
+        padding: 8px 12px;
+        border-radius: 8px;
+        background-color: #171717;
+        color: #ffffff;
+        font-size: 14px;
+        text-decoration: none;
+      }
+
+      .button:hover {
+        background-color: #2f2f2f;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="content">
+      <svg
+        width="40"
+        height="40"
+        viewBox="0 0 40 40"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        <path
+          d="M17.4 5.5a3 3 0 0 1 5.2 0l14.1 24.5a3 3 0 0 1-2.6 4.5H5.9a3 3 0 0 1-2.6-4.5L17.4 5.5Z"
+          stroke="#E5484D"
+          stroke-width="2.5"
+          stroke-linejoin="round"
+        />
+        <path
+          d="M20 15.5v6.5"
+          stroke="#E5484D"
+          stroke-width="2.5"
+          stroke-linecap="round"
+        />
+        <circle cx="20" cy="27.5" r="1.75" fill="#E5484D" />
+      </svg>
+      <div class="text">
+        <h1>This server took too long to respond</h1>
+        <p>Error: 504 Gateway Timeout</p>
+        <p>
+          The server that hosts this site did not answer in time. Every site on
+          that server is affected, so this is not a fault of this site.
+        </p>
+      </div>
+      <a class="button dashboard-url" href="https://frappecloud.com/dashboard"
+        >Check the dashboard</a
+      >
+    </div>
+    <p class="footer">
+      Site owner? Reach us at
+      <a href="https://support.frappe.io/" target="_blank" rel="noopener"
+        >support.frappe.io</a
+      >
+      if the site stays down.
+    </p>
+    <script>
+      // the dashboard link needs the site name, which only the browser knows here
+      document.querySelector(".dashboard-url").href =
+        `https://frappecloud.com/dashboard/sites/${window.location.hostname}`;
+    </script>
+  </body>
+</html>

--- a/agent/pages/server_unreachable.html
+++ b/agent/pages/server_unreachable.html
@@ -1,0 +1,145 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Server Unreachable</title>
+    <style>
+      *,
+      *::before,
+      *::after {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      html {
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+        color-scheme: light;
+      }
+
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
+          Cantarell, "Helvetica Neue", sans-serif;
+        background-color: #ffffff;
+        color: #171717;
+        min-height: 100vh;
+        padding: 24px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 48px;
+      }
+
+      .content {
+        max-width: 26rem;
+        text-align: center;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 16px;
+      }
+
+      .text {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      h1 {
+        font-size: 20px;
+        font-weight: 600;
+        line-height: 1.3;
+      }
+
+      p {
+        font-size: 14px;
+        line-height: 1.5;
+        color: #525252;
+      }
+
+      .footer {
+        font-size: 14px;
+        line-height: 1.5;
+        text-align: center;
+        color: #7c7c7c;
+      }
+
+      a {
+        color: #0070cc;
+      }
+
+      /* plain-html visited purple. must not reach .button, whose label is white */
+      a:not(.button):visited {
+        color: #551a8b;
+      }
+
+      .button {
+        display: inline-flex;
+        align-items: center;
+        padding: 8px 12px;
+        border-radius: 8px;
+        background-color: #171717;
+        color: #ffffff;
+        font-size: 14px;
+        text-decoration: none;
+      }
+
+      .button:hover {
+        background-color: #2f2f2f;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="content">
+      <svg
+        width="40"
+        height="40"
+        viewBox="0 0 40 40"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        <path
+          d="M17.4 5.5a3 3 0 0 1 5.2 0l14.1 24.5a3 3 0 0 1-2.6 4.5H5.9a3 3 0 0 1-2.6-4.5L17.4 5.5Z"
+          stroke="#E5484D"
+          stroke-width="2.5"
+          stroke-linejoin="round"
+        />
+        <path
+          d="M20 15.5v6.5"
+          stroke="#E5484D"
+          stroke-width="2.5"
+          stroke-linecap="round"
+        />
+        <circle cx="20" cy="27.5" r="1.75" fill="#E5484D" />
+      </svg>
+      <div class="text">
+        <h1>This server is not responding</h1>
+        <p>Error: 502 Bad Gateway</p>
+        <p>
+          The server that hosts this site is down. Every site on that server is
+          affected, so this is not a fault of this site.
+        </p>
+      </div>
+      <a class="button dashboard-url" href="https://frappecloud.com/dashboard"
+        >Check the dashboard</a
+      >
+    </div>
+    <p class="footer">
+      Site owner? Reach us at
+      <a href="https://support.frappe.io/" target="_blank" rel="noopener"
+        >support.frappe.io</a
+      >
+      if the site stays down.
+    </p>
+    <script>
+      // the dashboard link needs the site name, which only the browser knows here
+      document.querySelector(".dashboard-url").href =
+        `https://frappecloud.com/dashboard/sites/${window.location.hostname}`;
+    </script>
+  </body>
+</html>

--- a/agent/templates/README.md
+++ b/agent/templates/README.md
@@ -1,0 +1,86 @@
+# NGINX configuration
+
+The agent writes every NGINX file on a server from the templates in this directory.
+Do not edit the rendered files on a server. The next render overwrites them.
+
+## Templates and their targets
+
+| Template | Rendered to | Linked from | Written by |
+| --- | --- | --- | --- |
+| `nginx/nginx.conf.jinja2` | `<agent>/nginx/nginx.conf` | `/etc/nginx/nginx.conf` | `Server._generate_nginx_config` |
+| `agent/nginx.conf.jinja2` | `<agent>/nginx.conf` | `/etc/nginx/conf.d/agent.conf` | `Server._generate_agent_nginx_config` |
+| `proxy/nginx.conf.jinja2` | `<agent>/nginx/proxy.conf` | `/etc/nginx/conf.d/proxy.conf` | `Proxy._generate_proxy_config` |
+| `bench/nginx.conf.jinja2` | `<bench>/nginx.conf` | `include <benches>/*/nginx.conf` | `Bench.generate_nginx_config` |
+
+The press playbooks make the symbolic links when they set up the server.
+`nginx/nginx.conf.jinja2` holds the `http` block. It includes the other three files.
+A proxy server has `proxy.conf` and no bench files. An application server has one
+bench file for each bench and no `proxy.conf`.
+
+The agent does not call `nginx -s reload` directly. It sends a request to
+`NginxReloadManager` (`agent/nginx_reload_manager.py`), which collects the requests
+from a Redis queue and reloads once for the batch.
+
+## Request path
+
+A normal site request passes through three programs:
+
+1. The proxy server NGINX (`proxy.conf`) selects the upstream from the `$host` maps.
+2. The application server NGINX (`<bench>/nginx.conf`) serves static files and public
+   files. It sends everything else to the bench.
+3. Gunicorn runs the site.
+
+A standalone bench has no proxy in front of it. Its DNS points at the application
+server, so step 1 does not happen. The template renders a different server block for
+this case, behind `{% if standalone %}`.
+
+## Error pages
+
+The HTML files live in `agent/pages`. One copy on the server serves every bench, so a
+page cannot contain a site name or a bench name. The `internal_server_error.html` page
+needs the bench name for a log link, so the bench template substitutes the
+`__BENCH_NAME__` placeholder with `sub_filter`.
+
+The layer that owns a failure serves the page for it:
+
+| Status | Page | Served by | Meaning |
+| --- | --- | --- | --- |
+| 402 | `suspended.html`, `suspended_saas.html` | proxy, ports 10092 and 10093 | The site is suspended. |
+| 429 | `exceeded.html` | proxy, and standalone bench | The site is over its rate limit. |
+| 500 | `internal_server_error.html` | bench | The site raised an exception. |
+| 502 | `bad_gateway.html` | bench | Gunicorn is down. |
+| 503 | `deactivated.html` | proxy, port 10091 | The site is deactivated. |
+| 504 | `gateway_timeout.html` | bench | Gunicorn passed `http_timeout`. |
+
+The proxy sends a suspended, deactivated or unknown site to a local upstream on
+127.0.0.1. That upstream returns the status, and the proxy serves the page for it.
+
+The proxy does not intercept 502 and 504. A 502 or 504 from the bench passes through
+it and reaches the visitor. A 502 or 504 that the proxy makes itself means that the
+application server is down or slow, and NGINX serves its own default page. This split
+keeps a bench failure and a server failure apart. If the proxy itself is down, the
+visitor gets no page at all, because there is no HTTP response.
+
+Two rules control how these blocks work:
+
+- `error_page 502 /bad_gateway.html` keeps the 502 status. A page location is
+  `internal`, so a visitor cannot request it directly.
+- `proxy_intercept_errors on` only affects a status that has an `error_page` line.
+  Every other status passes through.
+
+Status 500 uses `sub_filter` and not `error_page`. Interception discards the response
+body, which would also remove the error pages of Frappe and the tracebacks of the API.
+
+## Test a template change
+
+The templates are Jinja2, so a syntax error only appears after a render. Check a change
+before you deploy it:
+
+1. Render the template with Jinja2 and a sample context. Render `bench/nginx.conf.jinja2`
+   two times, once with `standalone=True` and once with `standalone=False`.
+2. Put the output in an `http` block, and run `nginx -t` on it.
+3. Ignore the errors about the certificates, the ports and the log paths. Read the line
+   that reports the syntax.
+
+A local NGINX has no `headers-more` module. Remove the `more_set_headers` lines before
+the test, or build the module first.

--- a/agent/templates/README.md
+++ b/agent/templates/README.md
@@ -46,27 +46,39 @@ The layer that owns a failure serves the page for it:
 | Status | Page | Served by | Meaning |
 | --- | --- | --- | --- |
 | 402 | `suspended.html`, `suspended_saas.html` | proxy, ports 10092 and 10093 | The site is suspended. |
-| 429 | `exceeded.html` | proxy, and standalone bench | The site is over its rate limit. |
+| 429 | `exceeded.html` | bench | The site reached its daily usage limit. |
 | 500 | `internal_server_error.html` | bench | The site raised an exception. |
 | 502 | `bad_gateway.html` | bench | Gunicorn is down. |
+| 502 | `server_unreachable.html` | proxy | The application server is down. |
 | 503 | `deactivated.html` | proxy, port 10091 | The site is deactivated. |
 | 504 | `gateway_timeout.html` | bench | Gunicorn passed `http_timeout`. |
+| 504 | `server_timeout.html` | proxy | The application server did not answer in time. |
 
 The proxy sends a suspended, deactivated or unknown site to a local upstream on
 127.0.0.1. That upstream returns the status, and the proxy serves the page for it.
 
-The proxy does not intercept 502 and 504. A 502 or 504 from the bench passes through
-it and reaches the visitor. A 502 or 504 that the proxy makes itself means that the
-application server is down or slow, and NGINX serves its own default page. This split
-keeps a bench failure and a server failure apart. If the proxy itself is down, the
-visitor gets no page at all, because there is no HTTP response.
+Each layer serves a page for its own failures only. The bench owns 429, 500, 502 and
+504, because all four come from the site or from gunicorn. The proxy owns 402, 503 and
+the 502 and 504 that it makes itself. A 502 or 504 from the proxy means that it never
+reached the application server, so the site is not the cause. The bench pages name the
+site, and the proxy pages name the server. If the proxy itself is down, the visitor
+gets no page at all, because there is no HTTP response.
 
-Two rules control how these blocks work:
+Three rules of NGINX control how these blocks work:
 
+- `error_page` always catches a status that NGINX makes itself. A refused upstream
+  makes 502. A slow upstream makes 504. `limit_req` makes 429.
+- `proxy_intercept_errors on` adds the responses of the upstream to that. The bench
+  needs it, because gunicorn sends the 429 of the rate limiter of Frappe. The proxy
+  keeps it off, so that the pages of the bench pass through it.
 - `error_page 502 /bad_gateway.html` keeps the 502 status. A page location is
   `internal`, so a visitor cannot request it directly.
-- `proxy_intercept_errors on` only affects a status that has an `error_page` line.
-  Every other status passes through.
+
+Interception throws the response body away. Do not turn it on at the proxy for a
+status that the bench answers itself. The visitor then gets the page of the proxy for
+a failure of the bench, and the two layers become impossible to tell apart.
+`$upstream_status` cannot separate them. NGINX sets it to 502 both when the bench
+answers 502 and when the connection to the bench is refused.
 
 Status 500 uses `sub_filter` and not `error_page`. Interception discards the response
 body, which would also remove the error pages of Frappe and the tracebacks of the API.
@@ -84,3 +96,16 @@ before you deploy it:
 
 A local NGINX has no `headers-more` module. Remove the `more_set_headers` lines before
 the test, or build the module first.
+
+A change to an error page needs more than `nginx -t`. Start a local NGINX with the
+rendered config, and make each status happen:
+
+1. To get a 502, point the upstream at a port that nothing listens on.
+2. To get a 504, point the upstream at a server that sleeps, and lower
+   `proxy_read_timeout`.
+3. To get a status from the upstream itself, point the upstream at a small HTTP server
+   that returns that status with a body of its own. The body tells you if the layer
+   passed the response through, or replaced it with a page.
+
+Run the config of the bench and the config of the proxy separately. A page can only
+reach a visitor if every layer above it passes the response through.

--- a/agent/templates/bench/nginx.conf.jinja2
+++ b/agent/templates/bench/nginx.conf.jinja2
@@ -366,9 +366,20 @@ server {
 		sub_filter '__BENCH_NAME__' '{{ bench_name }}';
 	}
 
-	# 502/504 are intercepted here and not on the proxy, so that a proxy-generated
-	# 502/504 means the app server itself is down or slow, not this bench
+	# the bench serves the page for every failure of its own, and the proxy passes
+	# the response through. A 502 or 504 that the proxy makes instead means that it
+	# never reached this server, and it has its own pages for that
 	proxy_intercept_errors on;
+
+	# 429 comes from the rate limiter of frappe, so gunicorn sends it
+	error_page 429 /exceeded.html;
+	location /exceeded.html {
+		root {{ error_pages_directory }};
+		internal;
+	}
+
+	# 502 and 504 come from nginx, when gunicorn refuses the connection or passes
+	# http_timeout
 	error_page 502 /bad_gateway.html;
 	location /bad_gateway.html {
 		root {{ error_pages_directory }};

--- a/agent/templates/bench/nginx.conf.jinja2
+++ b/agent/templates/bench/nginx.conf.jinja2
@@ -190,6 +190,18 @@ server {
 		internal;
 	}
 
+	error_page 502 /bad_gateway.html;
+	location /bad_gateway.html {
+		root {{ error_pages_directory }};
+		internal;
+	}
+
+	error_page 504 /gateway_timeout.html;
+	location /gateway_timeout.html {
+		root {{ error_pages_directory }};
+		internal;
+	}
+
 	# optimizations
 	sendfile on;
 	keepalive_timeout 15;
@@ -352,6 +364,21 @@ server {
 		# one static page is shared by every bench on the server, so the link to this
 		# bench's web.error.log can only be completed here
 		sub_filter '__BENCH_NAME__' '{{ bench_name }}';
+	}
+
+	# 502/504 are intercepted here and not on the proxy, so that a proxy-generated
+	# 502/504 means the app server itself is down or slow, not this bench
+	proxy_intercept_errors on;
+	error_page 502 /bad_gateway.html;
+	location /bad_gateway.html {
+		root {{ error_pages_directory }};
+		internal;
+	}
+
+	error_page 504 /gateway_timeout.html;
+	location /gateway_timeout.html {
+		root {{ error_pages_directory }};
+		internal;
 	}
 
 	# optimizations

--- a/agent/templates/proxy/nginx.conf.jinja2
+++ b/agent/templates/proxy/nginx.conf.jinja2
@@ -255,18 +255,6 @@ server {
 		internal;
 	}
 
-	error_page 502 /bad_gateway.html;
-	location /bad_gateway.html {
-		root {{ error_pages_directory }};
-		internal;
-	}
-
-	error_page 504 /gateway_timeout.html;
-	location /gateway_timeout.html {
-		root {{ error_pages_directory }};
-		internal;
-	}
-
 	{% endif %}
 }
 

--- a/agent/templates/proxy/nginx.conf.jinja2
+++ b/agent/templates/proxy/nginx.conf.jinja2
@@ -248,9 +248,19 @@ server {
 		proxy_pass $upstream_server_hash;
 	}
 
-	proxy_intercept_errors on;
-	error_page 429 /exceeded.html;
-	location /exceeded.html {
+	# proxy_intercept_errors stays off here. Every status that the bench sends, and
+	# the page that goes with it, passes through untouched. These two pages are for
+	# the errors that this server makes, which mean that the app server is down or
+	# too slow. The bench never gets to answer in that case.
+	error_page 502 /server_unreachable.html;
+	error_page 504 /server_timeout.html;
+
+	location /server_unreachable.html {
+		root {{ error_pages_directory }};
+		internal;
+	}
+
+	location /server_timeout.html {
 		root {{ error_pages_directory }};
 		internal;
 	}


### PR DESCRIPTION
## Problem

Every branded error page was served by the proxy. The proxy makes a 502 or a 504 in
two very different cases:

- the bench nginx answered 502 or 504, because gunicorn is down or slow
- the proxy could not reach the app server at all, or the app server was slow

The visitor saw the same page either way, and the page sends them to the site
troubleshooting docs and the site dashboard. That advice is wrong when the whole app
server is down.

## Change

Each layer now serves the pages for its own failures.

**Bench** (`bench/nginx.conf.jinja2`), with `proxy_intercept_errors on`:

| Status | Page | Source |
| --- | --- | --- |
| 429 | `exceeded.html` | the rate limiter of frappe, sent by gunicorn |
| 502 | `bad_gateway.html` | gunicorn refused the connection |
| 504 | `gateway_timeout.html` | gunicorn passed `http_timeout` |

**Proxy** (`proxy/nginx.conf.jinja2`), with `proxy_intercept_errors` off:

| Status | Page | Source |
| --- | --- | --- |
| 502 | `server_unreachable.html` (new) | the app server refused the connection |
| 504 | `server_timeout.html` (new) | the app server did not answer in time |

The two new pages say "This server is not responding" and "This server took too long
to respond", where the bench pages say "This site …". A support screenshot now names
the layer.

### Why interception has to go off at the proxy

Interception throws the response body away. If the proxy keeps
`proxy_intercept_errors on` and defines `error_page 502`, a 502 from the bench comes
back as the page of the proxy, and the two failures look the same again.

`$upstream_status` cannot separate them. Nginx sets it to `502` both when the bench
answers 502 and when the connection to the bench is refused. This was measured, not
assumed.

With interception off, the proxy still serves its own pages, because `error_page`
always catches a status that nginx makes itself. The 429 page moves to the bench,
which is the layer that receives it from gunicorn.

### Not covered

If the proxy itself is down, the visitor gets no page. There is no HTTP response to
attach one to. Only something in front of the proxy can answer.

## Docs

`agent/templates/README.md` is new. It records which template renders which file,
where the files land on a server, which layer serves which page, and how to test a
template change.

## Testing

`python -m unittest agent.tests.test_pages` passes.

Both configs were rendered and served by a local nginx, and every status was forced:

| Config | Case | Result |
| --- | --- | --- |
| proxy | upstream refused | 502, `server_unreachable.html` |
| proxy | `return 504` | 504, `server_timeout.html` |
| proxy | upstream answered 502, 504, 429 with a body | passed through, body kept |
| bench | gunicorn refused | 502, `bad_gateway.html` |
| bench | gunicorn answered 429 | 429, `exceeded.html` |
| bench | gunicorn slower than `proxy_read_timeout` | 504, `gateway_timeout.html` |

`nginx -t` reports "syntax is ok" for the proxy config and for both variants of the
bench config, standalone and proxied.

### On a real server

Deployed to f1.local.frappe.dev (app server, 10 benches) and n1.local.frappe.dev (the
proxy in front of it), configs regenerated and reloaded:

| Case | Request | Result |
| --- | --- | --- |
| Bench stopped | `site1.local.frappe.dev` through the proxy | 502, `bad_gateway.html`, "This site is not responding" |
| Bench stopped | same site straight to f1, `Host` header set | 502, the same page, so the proxy passed it through |
| App server down | `newsite.local.frappe.dev`, whose server is off | 502, `server_unreachable.html`, "This server is not responding" |
| Healthy | `site1.local.frappe.dev` | 200 |

429 and 504 were not forced on the server. Both are covered by the local runs above.

### Size of the config

Rendered both template versions at 200 benches and 2000 proxy hosts, and measured
`nginx -t` and resident memory:

| Config | Lines | Parse | Resident |
| --- | --- | --- | --- |
| bench, old | 32,200 | 547 ms | 59 MB |
| bench, new | 37,400 | 546 ms | 69 MB |
| proxy, old | 280,154 | 997 ms | 1021 MB |
| proxy, new | 276,154 | 949 ms | 964 MB |

A bench config grows by 26 lines, which is three more `location` blocks and about 50 KB
of memory for each bench. Parse time does not move, which is what a reload repeats. The
proxy loses one error page location for each host, so it gets smaller and slightly
faster. No new `map` variable is added, so the hash sizes stay as they are.

## Rollout

A site keeps the old behavior until its bench config is regenerated. Until then the
429, 502 and 504 pages of that bench are gone, because the proxy no longer serves
them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
