### PR TITLE
fix(nginx): Remove unclosed string from headers

### DIFF
--- a/agent/templates/proxy/nginx.conf.jinja2
+++ b/agent/templates/proxy/nginx.conf.jinja2
@@ -115,7 +115,7 @@ map $upstream_http_access_control_allow_origin $access_control_allow_origin {
 
 map $upstream_http_access_control_allow_headers $access_control_allow_headers {
 	default $upstream_http_access_control_allow_headers;
-	"" "'Origin, Content-Type, Accept";
+	"" "Origin, Content-Type, Accept";
 }
 
 map $upstream_http_access_control_allow_credentials $access_control_allow_credentials {
@@ -125,7 +125,7 @@ map $upstream_http_access_control_allow_credentials $access_control_allow_creden
 
 map $upstream_http_access_control_allow_methods $access_control_allow_methods {
 	default $upstream_http_access_control_allow_methods;
-	"" "'GET, POST, OPTIONS";
+	"" "GET, POST, OPTIONS";
 }
 
 proxy_cache_path /tmp/cache keys_zone=proxy_cache_zone:10m loader_threshold=300 loader_files=200 max_size=200m;


### PR DESCRIPTION
This commit fixes unclosed strings in headers:

- `Access-Control-Allow-Headers`
- `Access-Control-Allow-Methods`

Currrent:

```
access-control-allow-headers
'Origin, Content-Type, Accept

access-control-allow-methods
'GET, POST, OPTIONS
```